### PR TITLE
Adding a dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # Update the GitHub actions used in our CI/CD workflow
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@panther-labs/platform"
+    assignees:
+      - "@panther-labs/platform"


### PR DESCRIPTION
Adding a dependabot config - matches the rest of the Panther repos.