### PR TITLE
Remove version for golangci-lint

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -40,11 +40,8 @@ jobs:
       - name: go mod download
         run: go mod download
 
-      - name: golangci-lint fmt
-        uses: golangci/golangci-lint-action@a5307c8f68bcd21ff73283f8629eb09caa60d7a7
-        with:
-          args: fmt
-
+      - name: Install gofumpt
+        run: go install mvdan.cc/gofumpt@latest
 
       - name: Check formatting
         run: |

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -19,7 +19,7 @@ jobs:
       - name: go mod download
         run: go mod download
 
-      - name: golangci-lint
+      - name: golangci-lint run
         uses: golangci/golangci-lint-action@a5307c8f68bcd21ff73283f8629eb09caa60d7a7
         with:
           args: --timeout 10m --verbose --allow-parallel-runners --max-same-issues 0 --max-issues-per-linter 0
@@ -40,8 +40,11 @@ jobs:
       - name: go mod download
         run: go mod download
 
-      - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@latest
+      - name: golangci-lint fmt
+        uses: golangci/golangci-lint-action@a5307c8f68bcd21ff73283f8629eb09caa60d7a7
+        with:
+          args: fmt
+
 
       - name: Check formatting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
         uses: golangci/golangci-lint-action@a5307c8f68bcd21ff73283f8629eb09caa60d7a7
         with:
           args: --timeout 10m --verbose --allow-parallel-runners --max-same-issues 0 --max-issues-per-linter 0
-          version: v1.64
 
       - name: Create release tag if not exists
         id: create_tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run tests
         run: go test -v ./pkg/...
 
-      - name: golangci-lint
+      - name: golangci-lint run
         uses: golangci/golangci-lint-action@a5307c8f68bcd21ff73283f8629eb09caa60d7a7
         with:
           args: --timeout 10m --verbose --allow-parallel-runners --max-same-issues 0 --max-issues-per-linter 0


### PR DESCRIPTION
<!--
This repo is made possible by contributors like you. Thank you.
Please include a high level overview of the changes made
-->

## Overview

<!-- What did you remove? -->
- `version:` for golangci-lint step in release GHA

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [x] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [ ] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: