### PR TITLE
remove unnecessary region field in AWSConfig

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -1,7 +1,6 @@
 AWSConfig:
   AccessKeyID: <YOUR AWS ACCESS KEY ID>
   SecretAccessKey: <YOUR AWS SECRET ACCESS KEY>
-  Region: <YOUR AWS REGION>
   CloudFormationConfig:
     DeploymentRoleName: PantherDeploymentRole # WE RECOMMEND USING THIS VALUE
     IdentityAccountId: <ASK FOR THIS INFORMATION FROM PANTHER>

--- a/pkg/cloudconnected/config/aws.go
+++ b/pkg/cloudconnected/config/aws.go
@@ -14,7 +14,7 @@ type AWSConfig struct {
 	AccessKeyID     string `yaml:"AccessKeyID"     validate:"required"`
 	SecretAccessKey string `yaml:"SecretAccessKey" validate:"required"`
 	SessionToken    string `yaml:"SessionToken"`
-	Region          string `yaml:"Region"          validate:"required,validPantherRegion"`
+	Region          string `yaml:"-"               validate:"required,validPantherRegion"`
 
 	CloudFormationConfig           CloudFormationConfig           `yaml:"CloudFormationConfig"           validate:"required"`
 	DomainCertificateConfiguration DomainCertificateConfiguration `yaml:"DomainCertificateConfiguration" validate:"required"`

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -41,6 +41,10 @@ func NewConfigFromPath(path string) (Config, error) {
 	// initialize defaults within the config, this is recursive
 	defaults.SetDefaults(&cfg)
 
+	// We need the region, but the customer doesn't need to provide it twice. It
+	// should always match up between the two configs.
+	cfg.AWSConfig.Region = cfg.NewAccountConfig.PantherRegion
+
 	// Read the OrgAdminPrivateKey from file
 	if cfg.SnowflakeOrgConfig.OrgAdminPrivateKeyPath != "" {
 		privateKey, err := os.ReadFile(cfg.SnowflakeOrgConfig.OrgAdminPrivateKeyPath)


### PR DESCRIPTION

<!--
This repo is made possible by contributors like you. Thank you.
Please include a high level overview of the changes made
-->

## Overview

We don't need the user to specify the AWS region. It's implied by the PantherRegion.

<!-- What did you add? -->

<!-- What did you change? -->

<!-- What did you remove? -->
- removed the `Region` field in `AWSConfig` in YAML. The field still exists and is set during config load/validation.

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [x] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: