### PR TITLE
Allow users to specify an existing snowflake account

### DIFF
--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -48,27 +48,25 @@ func main() {
 	currentState := stateManager.GetState()
 	util.LogDebugln(pp.Sprintln(currentState))
 
-	// Setup Snowflake if not already done
-	var createAcctRes snowflake.CreateAccountResult
+	var resolvedSnowflakeAccount *snowflake.ResolvedSnowflakeAcccount
 	if currentState.SnowflakeAccountDetails.AccountName == "" {
-		createAcctRes, err = setupSnowflakeAccount(ctx, cfg)
+		// Setup Snowflake if not already done
+		snowflakeSetup := snowflake.NewSnowflakeSetup(ctx, cfg)
+		resolvedSnowflakeAccount, err = snowflakeSetup.Run()
 		if err != nil {
 			log.Fatalf("failed to setup Snowflake: %v\n", err)
 		}
+
 		if err := stateManager.UpdateSnowflakeState(
 			cfg.SnowflakeConfig.NewAccountConfig.AdminUsername,
-			createAcctRes,
+			resolvedSnowflakeAccount,
 		); err != nil {
 			log.Fatalf("failed to update Snowflake state: %v\n", err)
 		}
+		log.Println("Successfully resolved Snowflake account")
 	} else {
-		createAcctRes = currentState.SnowflakeAccountDetails.CreateAccountResult
-		log.Println("Using existing Snowflake setup")
-	}
-	// idempotent, fine to run again if this is restarting from state
-	err = snowflakeAdminUserSetup(ctx, createAcctRes, cfg)
-	if err != nil {
-		log.Fatalf("failed to create Snowflake admin user: %v\n", err)
+		resolvedSnowflakeAccount = &currentState.SnowflakeAccountDetails.ResolvedSnowflakeAcccount
+		log.Println("Using existing Snowflake account details")
 	}
 
 	// Setup AWS if not already done
@@ -104,7 +102,7 @@ func main() {
 
 	// Run Snowflake credential bootstrap if not already done
 	if !currentState.AWSSnowflakeBootstrapSucceeded {
-		credsARN, err := runSnowflakeCredentialBootstrap(ctx, cfg, createAcctRes)
+		credsARN, err := runSnowflakeCredentialBootstrap(ctx, cfg, resolvedSnowflakeAccount)
 		if err != nil {
 			log.Fatalf("failed to run Snowflake credential bootstrap: %v\n", err)
 		}
@@ -352,50 +350,6 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 	}
 }
 
-// Uses orgadmin (provided with RSA key) to create a new account whose first admin user is
-// PANTHERACCOUNTADMIN with a newly generated RSA key.
-func setupSnowflakeAccount(ctx context.Context, cfg *config.Config) (snowflake.CreateAccountResult, error) {
-	snow := snowflake.AccountCreate{}
-
-	if err := snow.Connect(ctx, cfg.SnowflakeConfig.NewAccountConfig.OrgConfig); err != nil {
-		return snowflake.CreateAccountResult{}, errors.Wrap(err, "failed to connect to Snowflake")
-	}
-	defer func() {
-		if err := snow.Close(); err != nil {
-			log.Fatalf("failed to close Snowflake connection: %v\n", err)
-		}
-	}()
-
-	createAcctRes, err := snow.CreateNewSnowflakeAccount(cfg.SnowflakeConfig.NewAccountConfig)
-	if err != nil {
-		return snowflake.CreateAccountResult{}, errors.Wrap(err, "failed to create new Snowflake account")
-	}
-
-	return createAcctRes, nil
-}
-
-// Creates a type=person admin user for the customer based on the provided config.
-func snowflakeAdminUserSetup(
-	ctx context.Context,
-	createAcctRes snowflake.CreateAccountResult,
-	cfg *config.Config,
-) error {
-	snowAcctSetup := snowflake.AccountSetup{}
-	if err := snowAcctSetup.Connect(ctx, createAcctRes); err != nil {
-		return errors.Wrap(err, "failed to connect to new Snowflake account")
-	}
-	defer func() {
-		if err := snowAcctSetup.Close(); err != nil {
-			log.Fatalf("failed to close Snowflake account setup: %v\n", err)
-		}
-	}()
-
-	if err := snowAcctSetup.SetupCustomerAccountAdminUser(cfg.SnowflakeConfig.NewAccountConfig); err != nil {
-		return errors.Wrap(err, "failed to setup Panther account admin user")
-	}
-	return nil
-}
-
 func setupAWS(ctx context.Context, cfg *config.Config) error {
 	awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
 	if err != nil {
@@ -455,14 +409,14 @@ func runReadinessCheck(ctx context.Context, cfg *config.Config) (state.Readiness
 func runSnowflakeCredentialBootstrap(
 	ctx context.Context,
 	cfg *config.Config,
-	createAcctRes snowflake.CreateAccountResult,
+	resolvedSnowflakeAcct *snowflake.ResolvedSnowflakeAcccount,
 ) (string, error) {
 	bootstrap, err := aws.NewLocalSnowflakeCredentialBootstrap(ctx, cfg.AWSConfig)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to initialize Snowflake credential bootstrap")
 	}
 
-	credsARN, err := bootstrap.WriteSecret(ctx, createAcctRes)
+	credsARN, err := bootstrap.WriteSecret(ctx, resolvedSnowflakeAcct)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to execute Snowflake credential bootstrap")
 	}

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/config"
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/panther"
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/snowflake"
+	"github.com/panther-labs/panther-cli/pkg/rsapem"
 	"github.com/panther-labs/panther-cli/pkg/state"
 	"github.com/panther-labs/panther-cli/pkg/util"
 	"github.com/pkg/errors"
@@ -49,7 +50,7 @@ func main() {
 	util.LogDebugln(pp.Sprintln(currentState))
 
 	var resolvedSnowflakeAccount *snowflake.ResolvedSnowflakeAcccount
-	if currentState.SnowflakeAccountDetails.AccountName == "" {
+	if currentState.SnowflakeAccountName == "" {
 		// Setup Snowflake if not already done
 		snowflakeSetup := snowflake.NewSnowflakeSetup(ctx, cfg)
 		resolvedSnowflakeAccount, err = snowflakeSetup.Run()
@@ -57,16 +58,24 @@ func main() {
 			log.Fatalf("failed to setup Snowflake: %v\n", err)
 		}
 
-		if err := stateManager.UpdateSnowflakeState(
-			cfg.SnowflakeConfig.NewAccountConfig.AdminUsername,
-			resolvedSnowflakeAccount,
-		); err != nil {
+		if err := stateManager.UpdateSnowflakeState(resolvedSnowflakeAccount); err != nil {
 			log.Fatalf("failed to update Snowflake state: %v\n", err)
 		}
 		log.Println("Successfully resolved Snowflake account")
 	} else {
-		resolvedSnowflakeAccount = &currentState.SnowflakeAccountDetails.ResolvedSnowflakeAcccount
 		log.Println("Using existing Snowflake account details")
+
+		resolvedSnowflakeAccount = currentState.RenderNonSensitiveSnowflakeAccountDetails()
+		privateKeyAsStr, err := cfg.SnowflakeConfig.ExistingAccountConfig.LoadPantherAccountAdminRSAKey()
+		if err != nil {
+			log.Fatalf("failed to load existing Snowflake account's PANTHERACCOUNTADMIN RSA key: %s\n", err.Error())
+		}
+
+		privateKey, err := rsapem.ParseRSAPEMPrivateKey(privateKeyAsStr)
+		if err != nil {
+			log.Fatalf("failed to parse existing Snowflake account's PANTHERACCOUNTADMIN RSA key: %s\n", err.Error())
+		}
+		resolvedSnowflakeAccount.AdminRSAKey = privateKey
 	}
 
 	// Setup AWS if not already done
@@ -143,10 +152,10 @@ func writeJSONSupportFile(currentState *state.Row, cfg *config.Config) (string, 
 	// Get components for filename
 	subdomain := cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain
 	awsAccountID := cfg.AWSConfig.MustGetAWSAccountID()
-	snowflakeLocator := currentState.SnowflakeAccountDetails.AccountName
+	snowflakeAccountName := currentState.SnowflakeAccountName
 
 	// Construct filename
-	filename := fmt.Sprintf("%s-%s-%s-supportfile.json", subdomain, awsAccountID, snowflakeLocator)
+	filename := fmt.Sprintf("%s-%s-%s-supportfile.json", subdomain, awsAccountID, snowflakeAccountName)
 
 	// Check if file exists
 	if _, err := os.Stat(filename); err == nil {

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -66,14 +66,26 @@ func main() {
 		log.Println("Using existing Snowflake account details")
 
 		resolvedSnowflakeAccount = currentState.RenderNonSensitiveSnowflakeAccountDetails()
-		privateKeyAsStr, err := cfg.SnowflakeConfig.ExistingAccountConfig.LoadPantherAccountAdminRSAKey()
-		if err != nil {
-			log.Fatalf("failed to load existing Snowflake account's PANTHERACCOUNTADMIN RSA key: %s\n", err.Error())
+
+		var privateKeyAsStr string
+		switch cfg.SnowflakeConfig.ConfigType {
+		case config.SnowflakeConfigTypeExistingAccount:
+			pk, err := cfg.SnowflakeConfig.ExistingAccountConfig.LoadPantherAccountAdminRSAKey()
+			if err != nil {
+				log.Fatalf("failed to load existing Snowflake account's %s RSA key: %s\n", snowflake.PantherAccountAdminUserName, err.Error())
+			}
+			privateKeyAsStr = pk
+		case config.SnowflakeConfigTypeNewAccount:
+			pk, err := cfg.SnowflakeConfig.NewAccountConfig.LoadPantherAccountAdminRSAKey()
+			if err != nil {
+				log.Fatalf("failed to generate new Snowflake account's %s RSA key: %s\n", snowflake.PantherAccountAdminUserName, err.Error())
+			}
+			privateKeyAsStr = pk
 		}
 
 		privateKey, err := rsapem.ParseRSAPEMPrivateKey(privateKeyAsStr)
 		if err != nil {
-			log.Fatalf("failed to parse existing Snowflake account's PANTHERACCOUNTADMIN RSA key: %s\n", err.Error())
+			log.Fatalf("failed to parse existing Snowflake account's %s RSA key: %s\n", snowflake.PantherAccountAdminUserName, err.Error())
 		}
 		resolvedSnowflakeAccount.AdminRSAKey = privateKey
 	}

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -57,7 +57,6 @@ func main() {
 		}
 		if err := stateManager.UpdateSnowflakeState(
 			cfg.NewAccountConfig.AdminUsername,
-			cfg.NewAccountConfig.AdminPassword,
 			createAcctRes,
 		); err != nil {
 			log.Fatalf("failed to update Snowflake state: %v\n", err)

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -56,7 +56,7 @@ func main() {
 			log.Fatalf("failed to setup Snowflake: %v\n", err)
 		}
 		if err := stateManager.UpdateSnowflakeState(
-			cfg.NewAccountConfig.AdminUsername,
+			cfg.SnowflakeConfig.NewAccountConfig.AdminUsername,
 			createAcctRes,
 		); err != nil {
 			log.Fatalf("failed to update Snowflake state: %v\n", err)
@@ -135,7 +135,7 @@ func main() {
 
 // writeJSONSupportFile generates a JSON support file using the provided state and config
 // It returns the JSON string for possible further use
-func writeJSONSupportFile(currentState *state.Row, cfg config.Config) (string, error) {
+func writeJSONSupportFile(currentState *state.Row, cfg *config.Config) (string, error) {
 	// Generate JSON content
 	jsonStr, err := currentState.FormatJSON(cfg)
 	if err != nil {
@@ -225,7 +225,7 @@ func showLastRun(configFile string) {
 	util.LogDebugln(jsonStr)
 }
 
-func setupCertificates(ctx context.Context, cfg config.Config, stateManager *state.Manager) error {
+func setupCertificates(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
 	certHelper, err := aws.NewCertificateRegistrationHelper(ctx, cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize certificate registration helper")
@@ -257,7 +257,7 @@ func setupCertificates(ctx context.Context, cfg config.Config, stateManager *sta
 	return nil
 }
 
-func checkCertificateStatus(ctx context.Context, cfg config.Config, stateManager *state.Manager) error {
+func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
 	certHelper, err := aws.NewCertificateRegistrationHelper(ctx, cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize certificate registration helper")
@@ -354,10 +354,10 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 
 // Uses orgadmin (provided with RSA key) to create a new account whose first admin user is
 // PANTHERACCOUNTADMIN with a newly generated RSA key.
-func setupSnowflakeAccount(ctx context.Context, cfg config.Config) (snowflake.CreateAccountResult, error) {
+func setupSnowflakeAccount(ctx context.Context, cfg *config.Config) (snowflake.CreateAccountResult, error) {
 	snow := snowflake.AccountCreate{}
 
-	if err := snow.Connect(ctx, cfg.SnowflakeOrgConfig); err != nil {
+	if err := snow.Connect(ctx, cfg.SnowflakeConfig.NewAccountConfig.OrgConfig); err != nil {
 		return snowflake.CreateAccountResult{}, errors.Wrap(err, "failed to connect to Snowflake")
 	}
 	defer func() {
@@ -366,7 +366,7 @@ func setupSnowflakeAccount(ctx context.Context, cfg config.Config) (snowflake.Cr
 		}
 	}()
 
-	createAcctRes, err := snow.CreateNewSnowflakeAccount(cfg.NewAccountConfig)
+	createAcctRes, err := snow.CreateNewSnowflakeAccount(cfg.SnowflakeConfig.NewAccountConfig)
 	if err != nil {
 		return snowflake.CreateAccountResult{}, errors.Wrap(err, "failed to create new Snowflake account")
 	}
@@ -378,7 +378,7 @@ func setupSnowflakeAccount(ctx context.Context, cfg config.Config) (snowflake.Cr
 func snowflakeAdminUserSetup(
 	ctx context.Context,
 	createAcctRes snowflake.CreateAccountResult,
-	cfg config.Config,
+	cfg *config.Config,
 ) error {
 	snowAcctSetup := snowflake.AccountSetup{}
 	if err := snowAcctSetup.Connect(ctx, createAcctRes); err != nil {
@@ -390,13 +390,13 @@ func snowflakeAdminUserSetup(
 		}
 	}()
 
-	if err := snowAcctSetup.SetupCustomerAccountAdminUser(cfg.NewAccountConfig); err != nil {
+	if err := snowAcctSetup.SetupCustomerAccountAdminUser(cfg.SnowflakeConfig.NewAccountConfig); err != nil {
 		return errors.Wrap(err, "failed to setup Panther account admin user")
 	}
 	return nil
 }
 
-func setupAWS(ctx context.Context, cfg config.Config) error {
+func setupAWS(ctx context.Context, cfg *config.Config) error {
 	awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize AWS CloudFormation")
@@ -421,7 +421,7 @@ func setupAWS(ctx context.Context, cfg config.Config) error {
 	return nil
 }
 
-func runReadinessCheck(ctx context.Context, cfg config.Config) (state.ReadinessCheckResults, error) {
+func runReadinessCheck(ctx context.Context, cfg *config.Config) (state.ReadinessCheckResults, error) {
 	readinessCheck, err := panther.NewReadinessCheck(ctx, cfg.AWSConfig)
 	if err != nil {
 		return state.ReadinessCheckResults{}, errors.Wrap(err, "failed to initialize readiness check")
@@ -454,7 +454,7 @@ func runReadinessCheck(ctx context.Context, cfg config.Config) (state.ReadinessC
 
 func runSnowflakeCredentialBootstrap(
 	ctx context.Context,
-	cfg config.Config,
+	cfg *config.Config,
 	createAcctRes snowflake.CreateAccountResult,
 ) (string, error) {
 	bootstrap, err := aws.NewLocalSnowflakeCredentialBootstrap(ctx, cfg.AWSConfig)

--- a/pkg/cloudconnected/aws/certificates.go
+++ b/pkg/cloudconnected/aws/certificates.go
@@ -15,7 +15,7 @@ import (
 
 type CertificateRegistrationHelper struct {
 	ctx    context.Context
-	cfg    config.Config
+	cfg    *config.Config
 	client *acm.Client
 }
 
@@ -35,7 +35,7 @@ type CertificateRegistrationResult struct {
 
 func NewCertificateRegistrationHelper(
 	ctx context.Context,
-	cfg config.Config,
+	cfg *config.Config,
 ) (*CertificateRegistrationHelper, error) {
 	// Get AWS config using the utility helper
 	awsCfg, err := util.GetAWSConfig(

--- a/pkg/cloudconnected/aws/local_snowflake_credential_bootstrap.go
+++ b/pkg/cloudconnected/aws/local_snowflake_credential_bootstrap.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"log"
 	"time"
@@ -53,7 +52,7 @@ func NewLocalSnowflakeCredentialBootstrap(
 // WriteSecret writes the secret to AWS Secrets Manager as a JSON payload.
 func (l *LocalSnowflakeCredentialBootstrap) WriteSecret(
 	ctx context.Context,
-	createAccountResult snowflake.CreateAccountResult,
+	createAccountResult *snowflake.ResolvedSnowflakeAcccount,
 ) (string, error) {
 	err := updateSnowflakeSecret(ctx, l.secretsManager, snowflakeSecretName, createAccountResult)
 	if err != nil {
@@ -111,7 +110,7 @@ func (l *LocalSnowflakeCredentialBootstrap) ValidateSecret(ctx context.Context) 
 		asRsaPrivateKey,
 	)
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := snowflake.OpenSnowflakeAccountConnection(ctx, dsn)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open connection to Snowflake host: '%s'", secret.Host)
 	}
@@ -135,7 +134,7 @@ func updateSnowflakeSecret(
 	ctx context.Context,
 	sm *secretsmanager.Client,
 	secretName string,
-	createAcctResult snowflake.CreateAccountResult,
+	createAcctResult *snowflake.ResolvedSnowflakeAcccount,
 ) error {
 	getSecretValueInput := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretName),

--- a/pkg/cloudconnected/aws/local_snowflake_credential_bootstrap.go
+++ b/pkg/cloudconnected/aws/local_snowflake_credential_bootstrap.go
@@ -106,7 +106,7 @@ func (l *LocalSnowflakeCredentialBootstrap) ValidateSecret(ctx context.Context) 
 		"", // we don't need to specify region here
 		secret.Account,
 		secret.Username,
-		"ACCOUNTADMIN",
+		"ACCOUNTADMIN", // the snowflake role, not the user PANTHERACCOUNTADMIN
 		asRsaPrivateKey,
 	)
 
@@ -157,11 +157,11 @@ func updateSnowflakeSecret(
 
 	privateKey, err := rsapem.EncodeRSAPEMPrivateKey(createAcctResult.AdminRSAKey)
 	if err != nil {
-		return errors.Wrap(err, "encoding PrivateKey for PANTHERACCOUNTADMIN")
+		return errors.Wrapf(err, "encoding PrivateKey for %s", snowflake.PantherAccountAdminUserName)
 	}
 	publicKey, err := rsapem.EncodeRSAPEMPublicKey(&createAcctResult.AdminRSAKey.PublicKey)
 	if err != nil {
-		return errors.Wrap(err, "encoding PublicKey for PANTHERACCOUNTADMIN")
+		return errors.Wrapf(err, "encoding PublicKey for %s", snowflake.PantherAccountAdminUserName)
 	}
 	createTime := time.Now().UTC().Format(time.RFC3339)
 

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -44,27 +44,24 @@ func NewConfigFromPath(path string) (*Config, error) {
 
 	// We need the region, but the customer doesn't need to provide it twice. It
 	// should always match up between the two configs.
-	if err := setupAWSConfig(cfg); err != nil {
+	cfg.setupAWSConfig()
+
+	if err := cfg.setupSnowflakeConfig(); err != nil {
 		return nil, err
 	}
 
-	if err := setupSnowflakeConfig(cfg); err != nil {
-		return nil, err
-	}
-
-	if err := validateConfig(cfg); err != nil {
+	if err := cfg.validateConfig(); err != nil {
 		return nil, err
 	}
 
 	return cfg, nil
 }
 
-func setupAWSConfig(cfg *Config) (err error) {
+func (cfg *Config) setupAWSConfig() {
 	cfg.AWSConfig.Region = cfg.PantherAccountConfig.Region
-	return nil
 }
 
-func setupSnowflakeConfig(cfg *Config) (err error) {
+func (cfg *Config) setupSnowflakeConfig() (err error) {
 	// Set the type of SnowflakeConfig we are using
 	if cfg.SnowflakeConfig.NewAccountConfig != nil {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeNewAccount
@@ -99,7 +96,7 @@ func setupSnowflakeConfig(cfg *Config) (err error) {
 	return nil
 }
 
-func validateConfig(cfg *Config) (err error) {
+func (cfg *Config) validateConfig() (err error) {
 	if err := cfg.validate(); err != nil {
 		var validationErrs validator.ValidationErrors
 		if errors.As(err, &validationErrs) {

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -11,21 +11,21 @@ import (
 )
 
 type Config struct {
-	SnowflakeOrgConfig SnowflakeOrgConfig `yaml:"SnowflakeOrgConfig" validate:"required"`
-	NewAccountConfig   NewAccountConfig   `yaml:"NewAccountConfig"   validate:"required"`
-	AWSConfig          AWSConfig          `yaml:"AWSConfig"          validate:"required"`
+	AWSConfig            AWSConfig            `yaml:"AWSConfig"            validate:"required"`
+	SnowflakeConfig      SnowflakeConfig      `yaml:"SnowflakeConfig"      validate:"required"`
+	PantherAccountConfig PantherAccountConfig `yaml:"PantherAccountConfig" validate:"required"`
 }
 
 func (c Config) validate() error {
 	return validate.Struct(c)
 }
 
-func NewConfigFromPath(path string) (Config, error) {
-	var cfg Config
+func NewConfigFromPath(path string) (*Config, error) {
+	cfg := &Config{}
 
 	file, err := os.Open(path)
 	if err != nil {
-		return cfg, err
+		return nil, err
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -35,25 +35,58 @@ func NewConfigFromPath(path string) (Config, error) {
 
 	decoder := yaml.NewDecoder(file)
 	if err := decoder.Decode(&cfg); err != nil {
-		return cfg, err
+		return nil, err
 	}
 
 	// initialize defaults within the config, this is recursive
-	defaults.SetDefaults(&cfg)
+	defaults.SetDefaults(cfg)
 
 	// We need the region, but the customer doesn't need to provide it twice. It
 	// should always match up between the two configs.
-	cfg.AWSConfig.Region = cfg.NewAccountConfig.PantherRegion
-
-	// Read the OrgAdminPrivateKey from file
-	if cfg.SnowflakeOrgConfig.OrgAdminPrivateKeyPath != "" {
-		privateKey, err := os.ReadFile(cfg.SnowflakeOrgConfig.OrgAdminPrivateKeyPath)
-		if err != nil {
-			return cfg, err
-		}
-		cfg.SnowflakeOrgConfig.OrgAdminPrivateKey = string(privateKey)
+	if err := setupAWSConfig(cfg); err != nil {
+		return nil, err
 	}
 
+	if err := setupSnowflakeConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func setupAWSConfig(cfg *Config) (err error) {
+	cfg.AWSConfig.Region = cfg.PantherAccountConfig.Region
+	return nil
+}
+
+func setupSnowflakeConfig(cfg *Config) (err error) {
+	// Set the type of SnowflakeConfig we are using
+	if cfg.SnowflakeConfig.NewAccountConfig.IsEmpty() {
+		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeNewAccount
+
+		// Set the region for the NewAccountConfig based on the chosen Panther region.
+		cfg.SnowflakeConfig.NewAccountConfig.Region = cfg.AWSConfig.Region
+	} else if cfg.SnowflakeConfig.ExistingAccountConfig.IsEmpty() {
+		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeExistingAccount
+	}
+
+	// Read the OrgAdminPrivateKey from file if this is a NewAccountConfig
+	if cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath != "" {
+		privateKey, err := os.ReadFile(cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath)
+		if err != nil {
+			return err
+		}
+		cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKey = string(privateKey)
+	}
+
+	return nil
+}
+
+func validateConfig(cfg *Config) (err error) {
 	if err := cfg.validate(); err != nil {
 		var validationErrs validator.ValidationErrors
 		if errors.As(err, &validationErrs) {
@@ -61,8 +94,8 @@ func NewConfigFromPath(path string) (Config, error) {
 				log.Printf("Config field '%s' failed validation: %s\n", err.Field(), err.ActualTag())
 			}
 		}
-		return cfg, err
+		return err
 	}
 
-	return cfg, nil
+	return nil
 }

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -52,8 +52,6 @@ func NewConfigFromPath(path string) (*Config, error) {
 		return nil, err
 	}
 
-	log.Printf("Config:\n%s", pp.Sprint(cfg))
-
 	if err := validateConfig(cfg); err != nil {
 		return nil, err
 	}

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/k0kubun/pp/v3"
 	"github.com/mcuadros/go-defaults"
 	"gopkg.in/yaml.v3"
 )
@@ -51,6 +52,8 @@ func NewConfigFromPath(path string) (*Config, error) {
 		return nil, err
 	}
 
+	log.Printf("Config:\n%s", pp.Sprint(cfg))
+
 	if err := validateConfig(cfg); err != nil {
 		return nil, err
 	}
@@ -65,13 +68,15 @@ func setupAWSConfig(cfg *Config) (err error) {
 
 func setupSnowflakeConfig(cfg *Config) (err error) {
 	// Set the type of SnowflakeConfig we are using
-	if cfg.SnowflakeConfig.NewAccountConfig.IsEmpty() {
+	if !cfg.SnowflakeConfig.NewAccountConfig.IsEmpty() {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeNewAccount
 
 		// Set the region for the NewAccountConfig based on the chosen Panther region.
-		cfg.SnowflakeConfig.NewAccountConfig.Region = cfg.AWSConfig.Region
-	} else if cfg.SnowflakeConfig.ExistingAccountConfig.IsEmpty() {
+		cfg.SnowflakeConfig.NewAccountConfig.Region = cfg.PantherAccountConfig.Region
+	} else if !cfg.SnowflakeConfig.ExistingAccountConfig.IsEmpty() {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeExistingAccount
+	} else {
+		log.Fatalf("No SnowflakeConfig or invalid SnowflakeConfig provided:\n%s", pp.Sprint(cfg.SnowflakeConfig))
 	}
 
 	// Read the OrgAdminPrivateKey from file if this is a NewAccountConfig

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -68,24 +68,34 @@ func setupAWSConfig(cfg *Config) (err error) {
 
 func setupSnowflakeConfig(cfg *Config) (err error) {
 	// Set the type of SnowflakeConfig we are using
-	if !cfg.SnowflakeConfig.NewAccountConfig.IsEmpty() {
+	if cfg.SnowflakeConfig.NewAccountConfig != nil {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeNewAccount
 
 		// Set the region for the NewAccountConfig based on the chosen Panther region.
 		cfg.SnowflakeConfig.NewAccountConfig.Region = cfg.PantherAccountConfig.Region
-	} else if !cfg.SnowflakeConfig.ExistingAccountConfig.IsEmpty() {
+
+		log.Printf(
+			"Using Panther account config admin (email='%s', first name='%s', last name='%s') for new Snowflake account",
+			cfg.PantherAccountConfig.AdminEmail,
+			cfg.PantherAccountConfig.AdminUserFirstName,
+			cfg.PantherAccountConfig.AdminUserLastName,
+		)
+		cfg.SnowflakeConfig.NewAccountConfig.AdminEmail = cfg.PantherAccountConfig.AdminEmail
+		cfg.SnowflakeConfig.NewAccountConfig.AdminUserFirstName = cfg.PantherAccountConfig.AdminUserFirstName
+		cfg.SnowflakeConfig.NewAccountConfig.AdminUserLastName = cfg.PantherAccountConfig.AdminUserLastName
+
+		// Read the OrgAdminPrivateKey from file if this is a NewAccountConfig
+		if cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath != "" {
+			privateKey, err := os.ReadFile(cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath)
+			if err != nil {
+				return err
+			}
+			cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKey = string(privateKey)
+		}
+	} else if cfg.SnowflakeConfig.ExistingAccountConfig != nil {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeExistingAccount
 	} else {
 		log.Fatalf("No SnowflakeConfig or invalid SnowflakeConfig provided:\n%s", pp.Sprint(cfg.SnowflakeConfig))
-	}
-
-	// Read the OrgAdminPrivateKey from file if this is a NewAccountConfig
-	if cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath != "" {
-		privateKey, err := os.ReadFile(cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath)
-		if err != nil {
-			return err
-		}
-		cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKey = string(privateKey)
 	}
 
 	return nil

--- a/pkg/cloudconnected/config/panther.go
+++ b/pkg/cloudconnected/config/panther.go
@@ -1,0 +1,9 @@
+package config
+
+//nolint:lll
+type PantherAccountConfig struct {
+	DesiredPantherAccountName string   `yaml:"DesiredPantherAccountName" validate:"required"`
+	Edition                   string   `yaml:"PantherEdition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
+	Region                    string   `yaml:"PantherRegion"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
+	IpAddressAllowList        []string `yaml:"IpAddressAllowList"        validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
+}

--- a/pkg/cloudconnected/config/panther.go
+++ b/pkg/cloudconnected/config/panther.go
@@ -2,8 +2,8 @@ package config
 
 //nolint:lll
 type PantherAccountConfig struct {
-	DesiredPantherAccountName string   `yaml:"DesiredPantherAccountName" validate:"required"`
-	Edition                   string   `yaml:"PantherEdition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
-	Region                    string   `yaml:"PantherRegion"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
-	IpAddressAllowList        []string `yaml:"IpAddressAllowList"        validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
+	DesiredAccountName string   `yaml:"DesiredAccountName" validate:"required"`
+	Edition            string   `yaml:"Edition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
+	Region             string   `yaml:"Region"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
+	IpAddressAllowList []string `yaml:"IpAddressAllowList" validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
 }

--- a/pkg/cloudconnected/config/panther.go
+++ b/pkg/cloudconnected/config/panther.go
@@ -2,6 +2,9 @@ package config
 
 //nolint:lll
 type PantherAccountConfig struct {
+	AdminEmail         string   `yaml:"AdminEmail"         validate:"required,email"`
+	AdminUserFirstName string   `yaml:"AdminUserFirstName" validate:"required"`
+	AdminUserLastName  string   `yaml:"AdminUserLastName"  validate:"required"`
 	DesiredAccountName string   `yaml:"DesiredAccountName" validate:"required"`
 	Edition            string   `yaml:"Edition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
 	Region             string   `yaml:"Region"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only

--- a/pkg/cloudconnected/config/snowflake.go
+++ b/pkg/cloudconnected/config/snowflake.go
@@ -1,21 +1,22 @@
 package config
 
 import (
+	"os"
 	"strings"
 )
 
-type SnowflakeConfigType int
+type SnowflakeConfigType string
 
 const (
-	SnowflakeConfigTypeNewAccount SnowflakeConfigType = iota
-	SnowflakeConfigTypeExistingAccount
+	SnowflakeConfigTypeNewAccount      SnowflakeConfigType = "SnowflakeConfigTypeNewAccount"
+	SnowflakeConfigTypeExistingAccount SnowflakeConfigType = "SnowflakeConfigTypeExistingAccount"
 )
 
 //nolint:lll
 type SnowflakeConfig struct {
-	ConfigType            SnowflakeConfigType            `yaml:"-"                     validate:"required,oneof=NewAccountConfig ExistingAccountConfig"`
-	NewAccountConfig      NewSnowflakeAccountConfig      `yaml:"NewAccountConfig"      validate:"required_without=ExistingAccountConfig"`
-	ExistingAccountConfig ExistingSnowflakeAccountConfig `yaml:"ExistingAccountConfig" validate:"required_without=NewAccountConfig"`
+	ConfigType            SnowflakeConfigType             `yaml:"-"                     validate:"required,oneof=SnowflakeConfigTypeNewAccount SnowflakeConfigTypeExistingAccount"`
+	NewAccountConfig      *NewSnowflakeAccountConfig      `yaml:"NewAccountConfig"      validate:"required_without=ExistingAccountConfig,excluded_with=ExistingAccountConfig"`
+	ExistingAccountConfig *ExistingSnowflakeAccountConfig `yaml:"ExistingAccountConfig" validate:"required_without=NewAccountConfig,excluded_with=NewAccountConfig"`
 }
 
 //nolint:lll
@@ -29,21 +30,28 @@ type SnowflakeOrgConfig struct {
 
 //nolint:lll
 type ExistingSnowflakeAccountConfig struct {
-	AccountLocatorURL             string `yaml:"AccountLocatorURL"             validate:"required,url"`
+	AccountName                   string `yaml:"AccountName"                   validate:"required"`
 	URL                           string `yaml:"Url"                           validate:"required,url"`
 	Edition                       string `yaml:"Edition"                       validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"`
-	Region                        string `yaml:"SnowflakeRegion"               validate:"required,lowercase,validateSnowflakeRegion"`
+	Region                        string `yaml:"SnowflakeRegion"               validate:"required,lowercase,validSnowflakeRegion"`
 	PantherAccountAdminRSAKeyPath string `yaml:"PantherAccountAdminRSAKeyPath" validate:"required"`
 }
 
-func (c ExistingSnowflakeAccountConfig) IsEmpty() bool {
-	return c == ExistingSnowflakeAccountConfig{}
+func (e ExistingSnowflakeAccountConfig) IsEmpty() bool {
+	return e == ExistingSnowflakeAccountConfig{}
 }
 
-func (c ExistingSnowflakeAccountConfig) GetAWSRegion() string {
-	region := strings.ReplaceAll(c.Region, "_", "-")
-	region = strings.TrimLeft(region, "aws_")
-	return c.Region
+func (e ExistingSnowflakeAccountConfig) GetAWSRegion() string {
+	region := strings.TrimLeft(e.Region, "aws_")
+	return strings.ReplaceAll(region, "_", "-")
+}
+
+func (e ExistingSnowflakeAccountConfig) LoadPantherAccountAdminRSAKey() (string, error) {
+	privateKey, err := os.ReadFile(e.PantherAccountAdminRSAKeyPath)
+	if err != nil {
+		return "", err
+	}
+	return string(privateKey), nil
 }
 
 //nolint:lll

--- a/pkg/cloudconnected/config/snowflake.go
+++ b/pkg/cloudconnected/config/snowflake.go
@@ -1,8 +1,12 @@
 package config
 
 import (
+	"log"
 	"os"
 	"strings"
+
+	"github.com/k0kubun/pp/v3"
+	"github.com/pkg/errors"
 )
 
 type SnowflakeConfigType string
@@ -40,6 +44,7 @@ type ExistingSnowflakeAccountConfig struct {
 func (e *ExistingSnowflakeAccountConfig) LoadPantherAccountAdminRSAKey() (string, error) {
 	privateKey, err := os.ReadFile(e.PantherAccountAdminRSAKeyPath)
 	if err != nil {
+		log.Printf("failed to read PantherAccountAdminRSAKeyPath, error='%s', config section:\n%s", err, pp.Sprint(e))
 		return "", err
 	}
 	return string(privateKey), nil
@@ -48,6 +53,8 @@ func (e *ExistingSnowflakeAccountConfig) LoadPantherAccountAdminRSAKey() (string
 //nolint:lll
 type NewSnowflakeAccountConfig struct {
 	OrgConfig SnowflakeOrgConfig `yaml:"OrgConfig" validate:"required"`
+
+	PantherAccountAdminRSAKeyOutputPath string `yaml:"PantherAccountAdminRSAKeyOutputPath" validate:"required"`
 
 	AccountName        string `yaml:"SnowflakeAccountName" validate:"required,validAcctName"`
 	Edition            string `yaml:"SnowflakeEdition"     validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"` // if PantherEdition!=Enterprise, SnowflakeEdition can be whatever
@@ -62,4 +69,24 @@ type NewSnowflakeAccountConfig struct {
 func (n *NewSnowflakeAccountConfig) GetSnowflakeRegion() string {
 	region := strings.ReplaceAll(n.Region, "-", "_")
 	return "aws_" + region
+}
+
+func (n *NewSnowflakeAccountConfig) LoadPantherAccountAdminRSAKey() (string, error) {
+	if _, err := os.Stat(n.PantherAccountAdminRSAKeyOutputPath); os.IsNotExist(err) {
+		return "", errors.Errorf(
+			"It looks like you haven't created the new Snowflake account yet. The RSA keypair does not exist at location: %s",
+			n.PantherAccountAdminRSAKeyOutputPath,
+		)
+	}
+
+	privateKey, err := os.ReadFile(n.PantherAccountAdminRSAKeyOutputPath)
+	if err != nil {
+		log.Printf(
+			"failed to read PantherAccountAdminRSAKeyOutputPath, error='%s', config section:\n%s",
+			err,
+			pp.Sprint(n),
+		)
+		return "", err
+	}
+	return string(privateKey), nil
 }

--- a/pkg/cloudconnected/config/snowflake.go
+++ b/pkg/cloudconnected/config/snowflake.go
@@ -31,22 +31,13 @@ type SnowflakeOrgConfig struct {
 //nolint:lll
 type ExistingSnowflakeAccountConfig struct {
 	AccountName                   string `yaml:"AccountName"                   validate:"required"`
-	URL                           string `yaml:"Url"                           validate:"required,url"`
+	URL                           string `yaml:"URL"                           validate:"required,url"`
 	Edition                       string `yaml:"Edition"                       validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"`
-	Region                        string `yaml:"SnowflakeRegion"               validate:"required,lowercase,validSnowflakeRegion"`
+	Region                        string `yaml:"Region"                        validate:"required,lowercase,validPantherRegion"`
 	PantherAccountAdminRSAKeyPath string `yaml:"PantherAccountAdminRSAKeyPath" validate:"required"`
 }
 
-func (e ExistingSnowflakeAccountConfig) IsEmpty() bool {
-	return e == ExistingSnowflakeAccountConfig{}
-}
-
-func (e ExistingSnowflakeAccountConfig) GetAWSRegion() string {
-	region := strings.TrimLeft(e.Region, "aws_")
-	return strings.ReplaceAll(region, "_", "-")
-}
-
-func (e ExistingSnowflakeAccountConfig) LoadPantherAccountAdminRSAKey() (string, error) {
+func (e *ExistingSnowflakeAccountConfig) LoadPantherAccountAdminRSAKey() (string, error) {
 	privateKey, err := os.ReadFile(e.PantherAccountAdminRSAKeyPath)
 	if err != nil {
 		return "", err
@@ -62,17 +53,13 @@ type NewSnowflakeAccountConfig struct {
 	Edition            string `yaml:"SnowflakeEdition"     validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"` // if PantherEdition!=Enterprise, SnowflakeEdition can be whatever
 	AdminUsername      string `yaml:"AdminUsername"        validate:"required,validAdminName"`
 	AdminPassword      string `yaml:"AdminPassword"        validate:"required,min=32"`
-	AdminEmail         string `yaml:"AdminEmail"           validate:"required,email"`
-	AdminUserFirstName string `yaml:"AdminUserFirstName"   validate:"required"`
-	AdminUserLastName  string `yaml:"AdminUserLastName"    validate:"required"`
+	AdminEmail         string `yaml:"-"                    validate:"required,email"`
+	AdminUserFirstName string `yaml:"-"                    validate:"required"`
+	AdminUserLastName  string `yaml:"-"                    validate:"required"`
 	Region             string `yaml:"-"                    validate:"required,lowercase,validPantherRegion"`
 }
 
-func (c NewSnowflakeAccountConfig) IsEmpty() bool {
-	return c == NewSnowflakeAccountConfig{}
-}
-
-func (n NewSnowflakeAccountConfig) GetSnowflakeRegion() string {
+func (n *NewSnowflakeAccountConfig) GetSnowflakeRegion() string {
 	region := strings.ReplaceAll(n.Region, "-", "_")
 	return "aws_" + region
 }

--- a/pkg/cloudconnected/config/snowflake.go
+++ b/pkg/cloudconnected/config/snowflake.go
@@ -4,18 +4,26 @@ import (
 	"strings"
 )
 
+type SnowflakeConfigType int
+
+const (
+	SnowflakeConfigTypeNewAccount SnowflakeConfigType = iota
+	SnowflakeConfigTypeExistingAccount
+)
+
 //nolint:lll
 type SnowflakeConfig struct {
-	OrgConfig             SnowflakeOrgConfig             `yaml:"OrgConfig"             validate:"required_without=ExistingAccountConfigg"`
-	ExistingAccountConfig ExistingSnowflakeAccountConfig `yaml:"ExistingAccountConfig" validate:"required_without=OrgConfig"`
+	ConfigType            SnowflakeConfigType            `yaml:"-"                     validate:"required,oneof=NewAccountConfig ExistingAccountConfig"`
+	NewAccountConfig      NewSnowflakeAccountConfig      `yaml:"NewAccountConfig"      validate:"required_without=ExistingAccountConfig"`
+	ExistingAccountConfig ExistingSnowflakeAccountConfig `yaml:"ExistingAccountConfig" validate:"required_without=NewAccountConfig"`
 }
 
 //nolint:lll
 type SnowflakeOrgConfig struct {
 	AccountLocator         string `yaml:"AccountLocator"         validate:"required"`
-	AccountRegion          string `yaml:"AccountRegion"          validate:"required,validPantherRegion"`
+	AccountRegion          string `yaml:"AccountRegion"          validate:"required,lowercase,validPantherRegion"`
 	OrgAdminUsername       string `yaml:"OrgAdminUsername"       validate:"required"`
-	OrgAdminPrivateKey     string `yaml:"-"` // This will be populated from the file
+	OrgAdminPrivateKey     string `yaml:"-"                      validate:"required"                              json:"-"` // This will be populated from the file
 	OrgAdminPrivateKeyPath string `yaml:"OrgAdminPrivateKeyPath" validate:"required"`
 }
 
@@ -24,12 +32,24 @@ type ExistingSnowflakeAccountConfig struct {
 	AccountLocatorURL             string `yaml:"AccountLocatorURL"             validate:"required,url"`
 	URL                           string `yaml:"Url"                           validate:"required,url"`
 	Edition                       string `yaml:"Edition"                       validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"`
-	Region                        string `yaml:"SnowflakeRegion"               validate:"required,validateSnowflakeRegion"`
+	Region                        string `yaml:"SnowflakeRegion"               validate:"required,lowercase,validateSnowflakeRegion"`
 	PantherAccountAdminRSAKeyPath string `yaml:"PantherAccountAdminRSAKeyPath" validate:"required"`
+}
+
+func (c ExistingSnowflakeAccountConfig) IsEmpty() bool {
+	return c == ExistingSnowflakeAccountConfig{}
+}
+
+func (c ExistingSnowflakeAccountConfig) GetAWSRegion() string {
+	region := strings.ReplaceAll(c.Region, "_", "-")
+	region = strings.TrimLeft(region, "aws_")
+	return c.Region
 }
 
 //nolint:lll
 type NewSnowflakeAccountConfig struct {
+	OrgConfig SnowflakeOrgConfig `yaml:"OrgConfig" validate:"required"`
+
 	AccountName        string `yaml:"SnowflakeAccountName" validate:"required,validAcctName"`
 	Edition            string `yaml:"SnowflakeEdition"     validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"` // if PantherEdition!=Enterprise, SnowflakeEdition can be whatever
 	AdminUsername      string `yaml:"AdminUsername"        validate:"required,validAdminName"`
@@ -37,34 +57,14 @@ type NewSnowflakeAccountConfig struct {
 	AdminEmail         string `yaml:"AdminEmail"           validate:"required,email"`
 	AdminUserFirstName string `yaml:"AdminUserFirstName"   validate:"required"`
 	AdminUserLastName  string `yaml:"AdminUserLastName"    validate:"required"`
+	Region             string `yaml:"-"                    validate:"required,lowercase,validPantherRegion"`
 }
 
-//nolint:lll
-type PantherAccountConfig struct {
-	DesiredPantherAccountName string   `yaml:"DesiredPantherAccountName" validate:"required"`
-	Edition                   string   `yaml:"PantherEdition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
-	Region                    string   `yaml:"PantherRegion"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
-	IpAddressAllowList        []string `yaml:"IpAddressAllowList"        validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
+func (c NewSnowflakeAccountConfig) IsEmpty() bool {
+	return c == NewSnowflakeAccountConfig{}
 }
 
-//nolint:lll
-type NewAccountConfig struct {
-	SnowflakeAccountName string `yaml:"SnowflakeAccountName" validate:"required,validAcctName"`
-	SnowflakeEdition     string `yaml:"SnowflakeEdition"     validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"` // if PantherEdition!=Enterprise, SnowflakeEdition can be whatever
-
-	AdminUsername      string `yaml:"AdminUsername"      validate:"required,validAdminName"`
-	AdminPassword      string `yaml:"AdminPassword"      validate:"required,min=32"`
-	AdminEmail         string `yaml:"AdminEmail"         validate:"required,email"`
-	AdminUserFirstName string `yaml:"AdminUserFirstName" validate:"required"`
-	AdminUserLastName  string `yaml:"AdminUserLastName"  validate:"required"`
-
-	DesiredPantherAccountName string   `yaml:"DesiredPantherAccountName" validate:"required"`
-	PantherEdition            string   `yaml:"PantherEdition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
-	PantherRegion             string   `yaml:"PantherRegion"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
-	IpAddressAllowList        []string `yaml:"IpAddressAllowList"        validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
-}
-
-func (n NewAccountConfig) GetSnowflakeRegion() string {
-	region := strings.ReplaceAll(n.PantherRegion, "-", "_")
+func (n NewSnowflakeAccountConfig) GetSnowflakeRegion() string {
+	region := strings.ReplaceAll(n.Region, "-", "_")
 	return "aws_" + region
 }

--- a/pkg/cloudconnected/config/snowflake.go
+++ b/pkg/cloudconnected/config/snowflake.go
@@ -1,13 +1,50 @@
 package config
 
-import "strings"
+import (
+	"strings"
+)
 
+//nolint:lll
+type SnowflakeConfig struct {
+	OrgConfig             SnowflakeOrgConfig             `yaml:"OrgConfig"             validate:"required_without=ExistingAccountConfigg"`
+	ExistingAccountConfig ExistingSnowflakeAccountConfig `yaml:"ExistingAccountConfig" validate:"required_without=OrgConfig"`
+}
+
+//nolint:lll
 type SnowflakeOrgConfig struct {
 	AccountLocator         string `yaml:"AccountLocator"         validate:"required"`
 	AccountRegion          string `yaml:"AccountRegion"          validate:"required,validPantherRegion"`
 	OrgAdminUsername       string `yaml:"OrgAdminUsername"       validate:"required"`
 	OrgAdminPrivateKey     string `yaml:"-"` // This will be populated from the file
 	OrgAdminPrivateKeyPath string `yaml:"OrgAdminPrivateKeyPath" validate:"required"`
+}
+
+//nolint:lll
+type ExistingSnowflakeAccountConfig struct {
+	AccountLocatorURL             string `yaml:"AccountLocatorURL"             validate:"required,url"`
+	URL                           string `yaml:"Url"                           validate:"required,url"`
+	Edition                       string `yaml:"Edition"                       validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"`
+	Region                        string `yaml:"SnowflakeRegion"               validate:"required,validateSnowflakeRegion"`
+	PantherAccountAdminRSAKeyPath string `yaml:"PantherAccountAdminRSAKeyPath" validate:"required"`
+}
+
+//nolint:lll
+type NewSnowflakeAccountConfig struct {
+	AccountName        string `yaml:"SnowflakeAccountName" validate:"required,validAcctName"`
+	Edition            string `yaml:"SnowflakeEdition"     validate:"required,oneof=STANDARD ENTERPRISE BUSINESS_CRITICAL"` // if PantherEdition!=Enterprise, SnowflakeEdition can be whatever
+	AdminUsername      string `yaml:"AdminUsername"        validate:"required,validAdminName"`
+	AdminPassword      string `yaml:"AdminPassword"        validate:"required,min=32"`
+	AdminEmail         string `yaml:"AdminEmail"           validate:"required,email"`
+	AdminUserFirstName string `yaml:"AdminUserFirstName"   validate:"required"`
+	AdminUserLastName  string `yaml:"AdminUserLastName"    validate:"required"`
+}
+
+//nolint:lll
+type PantherAccountConfig struct {
+	DesiredPantherAccountName string   `yaml:"DesiredPantherAccountName" validate:"required"`
+	Edition                   string   `yaml:"PantherEdition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
+	Region                    string   `yaml:"PantherRegion"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
+	IpAddressAllowList        []string `yaml:"IpAddressAllowList"        validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
 }
 
 //nolint:lll

--- a/pkg/cloudconnected/config/validate.go
+++ b/pkg/cloudconnected/config/validate.go
@@ -21,11 +21,6 @@ func init() {
 	util.Must(validate.RegisterValidation("validPantherRegion", validatePantherRegion),
 		"couldn't register validPantherRegion validation",
 	)
-
-	util.Must(validate.RegisterValidation("validSnowflakeRegion", validateSnowflakeRegion),
-		"couldn't register validSnowflakeRegion validation",
-	)
-
 	validate.RegisterStructValidation(validateEditionsMatch, Config{})
 }
 
@@ -86,26 +81,6 @@ func validatePantherRegion(fl validator.FieldLevel) bool {
 		"us-east-1",
 		"us-east-2",
 		"us-west-2",
-	}
-
-	return slices.Contains(validRegions, fl.Field().String())
-}
-
-func validateSnowflakeRegion(fl validator.FieldLevel) bool {
-	validRegions := []string{
-		"aws_ap_northeast_1",
-		"aws_ap_northeast_2",
-		"aws_ap_south_1",
-		"aws_ap_southeast_1",
-		"aws_ap_southeast_2",
-		"aws_ca_central_1",
-		"aws_eu_central_1",
-		"aws_eu_west_1",
-		"aws_eu_west_2",
-		"aws_eu_west_3",
-		"aws_us_east_1",
-		"aws_us_east_2",
-		"aws_us_west_2",
 	}
 
 	return slices.Contains(validRegions, fl.Field().String())

--- a/pkg/cloudconnected/config/validate.go
+++ b/pkg/cloudconnected/config/validate.go
@@ -41,10 +41,25 @@ func validateAdminName(fl validator.FieldLevel) bool {
 
 func validateEditionsMatch(sl validator.StructLevel) {
 	cfg := sl.Current().Interface().(Config)
-	if cfg.PantherAccountConfig.Edition == "ENTERPRISE" &&
-		(cfg.SnowflakeConfig.NewAccountConfig.Edition != "ENTERPRISE" || cfg.SnowflakeConfig.ExistingAccountConfig.Edition != "ENTERPRISE") {
+
+	var specifiedEdition string
+	if cfg.SnowflakeConfig.NewAccountConfig != nil {
+		specifiedEdition = cfg.SnowflakeConfig.NewAccountConfig.Edition
+	} else if cfg.SnowflakeConfig.ExistingAccountConfig != nil {
+		specifiedEdition = cfg.SnowflakeConfig.ExistingAccountConfig.Edition
+	} else {
 		sl.ReportError(
-			cfg.SnowflakeConfig.NewAccountConfig.Edition,
+			cfg.PantherAccountConfig.Edition,
+			"PantherEdition",
+			"PantherEdition",
+			"eqfield",
+			"No Edition appears to have been specified",
+		)
+	}
+
+	if cfg.PantherAccountConfig.Edition == "ENTERPRISE" && specifiedEdition != "ENTERPRISE" {
+		sl.ReportError(
+			specifiedEdition,
 			"SnowflakeEdition",
 			"SnowflakeEdition",
 			"eqfield",

--- a/pkg/cloudconnected/config/validate.go
+++ b/pkg/cloudconnected/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"regexp"
+	"slices"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/panther-labs/panther-cli/pkg/util"
@@ -21,7 +22,11 @@ func init() {
 		"couldn't register validPantherRegion validation",
 	)
 
-	validate.RegisterStructValidation(validateEditionsMatch, NewAccountConfig{})
+	util.Must(validate.RegisterValidation("validSnowflakeRegion", validateSnowflakeRegion),
+		"couldn't register validSnowflakeRegion validation",
+	)
+
+	validate.RegisterStructValidation(validateEditionsMatch, Config{})
 }
 
 func validateSnowflakeAccountName(fl validator.FieldLevel) bool {
@@ -35,10 +40,11 @@ func validateAdminName(fl validator.FieldLevel) bool {
 }
 
 func validateEditionsMatch(sl validator.StructLevel) {
-	cfg := sl.Current().Interface().(NewAccountConfig)
-	if cfg.PantherEdition == "ENTERPRISE" && cfg.SnowflakeEdition != "ENTERPRISE" {
+	cfg := sl.Current().Interface().(Config)
+	if cfg.PantherAccountConfig.Edition == "ENTERPRISE" &&
+		(cfg.SnowflakeConfig.NewAccountConfig.Edition != "ENTERPRISE" || cfg.SnowflakeConfig.ExistingAccountConfig.Edition != "ENTERPRISE") {
 		sl.ReportError(
-			cfg.SnowflakeEdition,
+			cfg.SnowflakeConfig.NewAccountConfig.Edition,
 			"SnowflakeEdition",
 			"SnowflakeEdition",
 			"eqfield",
@@ -67,10 +73,25 @@ func validatePantherRegion(fl validator.FieldLevel) bool {
 		"us-west-2",
 	}
 
-	for _, region := range validRegions {
-		if fl.Field().String() == region {
-			return true
-		}
+	return slices.Contains(validRegions, fl.Field().String())
+}
+
+func validateSnowflakeRegion(fl validator.FieldLevel) bool {
+	validRegions := []string{
+		"aws_ap_northeast_1",
+		"aws_ap_northeast_2",
+		"aws_ap_south_1",
+		"aws_ap_southeast_1",
+		"aws_ap_southeast_2",
+		"aws_ca_central_1",
+		"aws_eu_central_1",
+		"aws_eu_west_1",
+		"aws_eu_west_2",
+		"aws_eu_west_3",
+		"aws_us_east_1",
+		"aws_us_east_2",
+		"aws_us_west_2",
 	}
-	return false
+
+	return slices.Contains(validRegions, fl.Field().String())
 }

--- a/pkg/cloudconnected/panther/readiness_check.go
+++ b/pkg/cloudconnected/panther/readiness_check.go
@@ -72,7 +72,11 @@ func (r *ReadinessCheck) Exec() (ReadinessCheckResult, error) {
 
 	// Check if the Lambda invocation was successful
 	if output.FunctionError != nil && *output.FunctionError != "" {
-		return ReadinessCheckResult{}, errors.Errorf("Lambda function error: %s", *output.FunctionError)
+		return ReadinessCheckResult{}, errors.Errorf(
+			"Lambda function error: %s - payload=\n%s",
+			*output.FunctionError,
+			string(output.Payload),
+		)
 	}
 
 	// Unmarshal the Lambda response

--- a/pkg/cloudconnected/snowflake/account_create.go
+++ b/pkg/cloudconnected/snowflake/account_create.go
@@ -74,7 +74,7 @@ func (a *AccountCreate) mustSwitchToOrgAdminRole() {
 }
 
 // New accounts are created with PANTHERACCOUNTADMIN and a newly generated RSA key
-func (a *AccountCreate) CreateNewSnowflakeAccount(cfg config.NewAccountConfig) (CreateAccountResult, error) {
+func (a *AccountCreate) CreateNewSnowflakeAccount(cfg config.NewSnowflakeAccountConfig) (CreateAccountResult, error) {
 	if !a.isConnected() {
 		return CreateAccountResult{}, errors.New("not connected to Snowflake")
 	}
@@ -106,9 +106,9 @@ CREATE ACCOUNT %s
 
 	row := a.sql.QueryRowContext(
 		a.ctx,
-		fmt.Sprintf(query, cfg.SnowflakeAccountName), // we cannot parameterize the account name
+		fmt.Sprintf(query, cfg.AccountName), // we cannot parameterize the account name
 		pubkey,
-		cfg.SnowflakeEdition,
+		cfg.Edition,
 		cfg.GetSnowflakeRegion(),
 	)
 

--- a/pkg/cloudconnected/snowflake/account_create.go
+++ b/pkg/cloudconnected/snowflake/account_create.go
@@ -2,10 +2,12 @@ package snowflake
 
 import (
 	"context"
+	"crypto/rsa"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/k0kubun/pp/v3"
 	"github.com/pkg/errors"
@@ -64,6 +66,46 @@ func (a *AccountCreate) mustSwitchToOrgAdminRole() {
 	}
 }
 
+// CreateAndWritePantherAccountAdminRSAKeyPair generates a new RSA key pair,
+// writes the private key (PEM encoded) to the path specified in cfg.PantherAccountAdminRSAKeyOutputPath,
+// and returns the private key object and the PEM encoded public key string.
+func CreateAndWritePantherAccountAdminRSAKeyPair(
+	cfg *config.NewSnowflakeAccountConfig,
+) (*rsa.PrivateKey, string, error) {
+	key, err := rsapem.GenerateKeyPair()
+	if err != nil {
+		return nil, "", errors.Wrap(err, fmt.Sprintf("failed to generate %s RSA key pair", PantherAccountAdminUserName))
+	}
+
+	pubkeyPEM, err := rsapem.EncodeRSAPEMPublicKey(key.PublicKey)
+	if err != nil {
+		return nil, "", errors.Wrap(err, fmt.Sprintf("failed to encode %s RSA public key", PantherAccountAdminUserName))
+	}
+
+	// Encode and write the private key to the specified output path
+	privKeyPEMBytes, err := rsapem.EncodeRSAPEMPrivateKey(key.PrivateKey)
+	if err != nil {
+		return nil, "", errors.Wrapf(
+			err,
+			"failed to encode %s RSA private key",
+			PantherAccountAdminUserName,
+		)
+	}
+	// Ensure the key is written with restricted permissions (owner read/write only)
+	err = os.WriteFile(cfg.PantherAccountAdminRSAKeyOutputPath, []byte(privKeyPEMBytes), 0o600)
+	if err != nil {
+		return nil, "", errors.Wrapf(
+			err,
+			"failed to write %s RSA private key to %s",
+			PantherAccountAdminUserName,
+			cfg.PantherAccountAdminRSAKeyOutputPath,
+		)
+	}
+	log.Printf("Wrote %s RSA private key to %s", PantherAccountAdminUserName, cfg.PantherAccountAdminRSAKeyOutputPath)
+
+	return key.PrivateKey, pubkeyPEM, nil
+}
+
 // New accounts are created with PANTHERACCOUNTADMIN and a newly generated RSA key
 func (a *AccountCreate) CreateNewSnowflakeAccount(
 	cfg *config.NewSnowflakeAccountConfig,
@@ -76,18 +118,14 @@ func (a *AccountCreate) CreateNewSnowflakeAccount(
 
 	createAcctRes := &ResolvedSnowflakeAcccount{}
 
-	key, err := rsapem.GenerateKeyPair()
+	privateKey, pubkeyPEM, err := CreateAndWritePantherAccountAdminRSAKeyPair(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate PANTHERACCOUNTADMIN RSA key pair")
-	}
-	pubkey, err := rsapem.EncodeRSAPEMPublicKey(key.PublicKey)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to encode PANTHERACCOUNTADMIN RSA public key")
+		return nil, err
 	}
 
 	const query = `
 CREATE ACCOUNT %s
-  ADMIN_NAME = 'PANTHERACCOUNTADMIN'
+  ADMIN_NAME = ?
   ADMIN_RSA_PUBLIC_KEY = ?
   ADMIN_USER_TYPE = 'SERVICE'
   MUST_CHANGE_PASSWORD = FALSE
@@ -100,7 +138,8 @@ CREATE ACCOUNT %s
 	row := a.sql.QueryRowContext(
 		a.ctx,
 		fmt.Sprintf(query, cfg.AccountName), // we cannot parameterize the account name
-		pubkey,
+		PantherAccountAdminUserName,
+		pubkeyPEM,
 		cfg.Edition,
 		cfg.GetSnowflakeRegion(),
 	)
@@ -115,9 +154,18 @@ CREATE ACCOUNT %s
 		return createAcctRes, errors.Wrap(err, "error unmarshalling of CREATE ACCOUNT output")
 	}
 
+	// Snowflake is weird and when you create an account, it returns the account name
+	// without the parent organization prefix. That prefix lives in the `URL` field in the
+	// response payload.
+	fullyQualifiedAccountName, err := createAcctRes.GetFullyQualifiedAccountName()
+	if err != nil {
+		return createAcctRes, errors.Wrap(err, "error getting fully qualified account name")
+	}
+	createAcctRes.AccountName = fullyQualifiedAccountName
+
 	log.Printf("Created new Snowflake account: %v", pp.Sprintln(createAcctRes))
 	// log before adding the RSA key to the result
-	createAcctRes.AdminRSAKey = key.PrivateKey
+	createAcctRes.AdminRSAKey = privateKey
 
 	return createAcctRes, nil
 }

--- a/pkg/cloudconnected/snowflake/account_create.go
+++ b/pkg/cloudconnected/snowflake/account_create.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/config"
 	"github.com/panther-labs/panther-cli/pkg/rsapem"
-	"github.com/panther-labs/panther-cli/pkg/util"
 )
 
 // Configuration for Snowflake connection is by using the
@@ -24,19 +23,11 @@ type AccountCreate struct {
 }
 
 func (a *AccountCreate) Connect(ctx context.Context, cfg config.SnowflakeOrgConfig) error {
-	tryEnableSnowflakeDebugLogging()
-
 	dsn := formatSnowflakeDSNFromSnowflakeOrgConfig(cfg)
-	util.LogDebugf("Connecting to Snowflake with DSN: %s", dsn)
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := openSnowflakeAccountConnection(ctx, dsn)
 	if err != nil {
-		return errors.Wrap(err, "failed to open connection")
-	}
-
-	// Test the connection to make sure it's actually valid.
-	if err := db.Ping(); err != nil {
-		return errors.Wrap(err, "failed to ping database")
+		return errors.Wrap(err, "failed to open Snowflake account connection")
 	}
 
 	a.sql = db
@@ -74,22 +65,24 @@ func (a *AccountCreate) mustSwitchToOrgAdminRole() {
 }
 
 // New accounts are created with PANTHERACCOUNTADMIN and a newly generated RSA key
-func (a *AccountCreate) CreateNewSnowflakeAccount(cfg config.NewSnowflakeAccountConfig) (CreateAccountResult, error) {
+func (a *AccountCreate) CreateNewSnowflakeAccount(
+	cfg *config.NewSnowflakeAccountConfig,
+) (*ResolvedSnowflakeAcccount, error) {
 	if !a.isConnected() {
-		return CreateAccountResult{}, errors.New("not connected to Snowflake")
+		return nil, errors.New("not connected to Snowflake")
 	}
 
 	a.mustSwitchToOrgAdminRole()
 
-	var createAcctRes CreateAccountResult
+	createAcctRes := &ResolvedSnowflakeAcccount{}
 
 	key, err := rsapem.GenerateKeyPair()
 	if err != nil {
-		return CreateAccountResult{}, errors.Wrap(err, "failed to generate PANTHERACCOUNTADMIN RSA key pair")
+		return nil, errors.Wrap(err, "failed to generate PANTHERACCOUNTADMIN RSA key pair")
 	}
 	pubkey, err := rsapem.EncodeRSAPEMPublicKey(key.PublicKey)
 	if err != nil {
-		return CreateAccountResult{}, errors.Wrap(err, "failed to encode PANTHERACCOUNTADMIN RSA public key")
+		return nil, errors.Wrap(err, "failed to encode PANTHERACCOUNTADMIN RSA public key")
 	}
 
 	const query = `

--- a/pkg/cloudconnected/snowflake/account_setup.go
+++ b/pkg/cloudconnected/snowflake/account_setup.go
@@ -27,7 +27,7 @@ func (a *AccountSetup) Connect(ctx context.Context, newAcct *ResolvedSnowflakeAc
 	dsn := util.FormatSnowflakeDSNFromRSAKey(
 		newAcct.GetAWSRegion(),
 		newAcct.AccountLocator,
-		"PANTHERACCOUNTADMIN",
+		PantherAccountAdminUserName,
 		"ACCOUNTADMIN",
 		newAcct.AdminRSAKey,
 	)

--- a/pkg/cloudconnected/snowflake/account_setup.go
+++ b/pkg/cloudconnected/snowflake/account_setup.go
@@ -21,15 +21,15 @@ type AccountSetup struct {
 	ctx  context.Context
 }
 
-func (a *AccountSetup) Connect(ctx context.Context, cfg CreateAccountResult) error {
+func (a *AccountSetup) Connect(ctx context.Context, newAcct *ResolvedSnowflakeAcccount) error {
 	tryEnableSnowflakeDebugLogging()
 
 	dsn := util.FormatSnowflakeDSNFromRSAKey(
-		cfg.GetAWSRegion(),
-		cfg.AccountLocator,
+		newAcct.GetAWSRegion(),
+		newAcct.AccountLocator,
 		"PANTHERACCOUNTADMIN",
 		"ACCOUNTADMIN",
-		cfg.AdminRSAKey,
+		newAcct.AdminRSAKey,
 	)
 	util.LogDebugf("Connecting to Snowflake with DSN: %s", dsn)
 
@@ -41,17 +41,10 @@ func (a *AccountSetup) Connect(ctx context.Context, cfg CreateAccountResult) err
 		log.Println(
 			"Attempting to connect to new Snowflake account. This may take a while and you may see this message repeat.",
 		)
-		db, err := sql.Open("snowflake", dsn)
+		db, err := openSnowflakeAccountConnection(ctx, dsn)
 		if err != nil {
-			return errors.Wrap(err, "failed to open connection")
+			return errors.Wrap(err, "failed to open Snowflake account connection")
 		}
-
-		// Test the connection to make sure it's actually valid.
-		if err := db.Ping(); err != nil {
-			return errors.Wrap(err, "failed to ping database")
-		}
-
-		log.Printf("Successfully connected to new Snowflake account (%s)", cfg.AccountLocator)
 
 		a.sql = db
 		a.ctx = ctx
@@ -60,7 +53,11 @@ func (a *AccountSetup) Connect(ctx context.Context, cfg CreateAccountResult) err
 	}
 
 	if err := backoff.Retry(oper, util.GetDefaultExponentialBackoffRetrier()); err != nil {
-		util.LogDebugf("Failed to connect to new Snowflake account (%s) after retries: %v\n", cfg.AccountLocator, err)
+		util.LogDebugf(
+			"Failed to connect to new Snowflake account (%s) after retries: %v\n",
+			newAcct.AccountLocator,
+			err,
+		)
 		return errors.Wrap(err, "failed to connect to new Snowflake account")
 	}
 
@@ -106,7 +103,7 @@ func (a *AccountSetup) mustSwitchToSecurityAdminRole() {
 	}
 }
 
-func (a *AccountSetup) SetupCustomerAccountAdminUser(cfg config.NewSnowflakeAccountConfig) error {
+func (a *AccountSetup) SetupCustomerAccountAdminUser(cfg *config.NewSnowflakeAccountConfig) error {
 	if !a.isConnected() {
 		return errors.New("not connected to Snowflake")
 	}

--- a/pkg/cloudconnected/snowflake/account_setup.go
+++ b/pkg/cloudconnected/snowflake/account_setup.go
@@ -106,7 +106,7 @@ func (a *AccountSetup) mustSwitchToSecurityAdminRole() {
 	}
 }
 
-func (a *AccountSetup) SetupCustomerAccountAdminUser(cfg config.NewAccountConfig) error {
+func (a *AccountSetup) SetupCustomerAccountAdminUser(cfg config.NewSnowflakeAccountConfig) error {
 	if !a.isConnected() {
 		return errors.New("not connected to Snowflake")
 	}

--- a/pkg/cloudconnected/snowflake/snowflake.go
+++ b/pkg/cloudconnected/snowflake/snowflake.go
@@ -1,0 +1,101 @@
+package snowflake
+
+import (
+	"context"
+	"log"
+
+	"github.com/panther-labs/panther-cli/pkg/cloudconnected/config"
+	"github.com/panther-labs/panther-cli/pkg/rsapem"
+	"github.com/pkg/errors"
+)
+
+type SnowflakeSetup struct {
+	ctx context.Context
+	cfg *config.Config
+}
+
+func NewSnowflakeSetup(ctx context.Context, cfg *config.Config) *SnowflakeSetup {
+	return &SnowflakeSetup{ctx, cfg}
+}
+
+func (s *SnowflakeSetup) Run() (resolvedAccount *ResolvedSnowflakeAcccount, err error) {
+	if s.cfg.SnowflakeConfig.ConfigType == config.SnowflakeConfigTypeNewAccount {
+		// create the account
+		resolvedAccount, err = s.createSnowflakeAccount()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create Snowflake account")
+		}
+
+		// setup the account
+		if err := s.setupSnowflakeAdmin(resolvedAccount); err != nil {
+			return nil, errors.Wrap(err, "failed to setup Snowflake account")
+		}
+	} else {
+		// fill out createAccountResult with the existing account details
+		privateKeyAsStr, err := s.cfg.SnowflakeConfig.ExistingAccountConfig.LoadPantherAccountAdminRSAKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load Panther account admin RSA key")
+		}
+
+		privateKey, err := rsapem.ParseRSAPEMPrivateKey(privateKeyAsStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode Panther account admin RSA key")
+		}
+
+		resolvedAccount = &ResolvedSnowflakeAcccount{
+			AccountName: s.cfg.SnowflakeConfig.ExistingAccountConfig.AccountName,
+			URL:         s.cfg.SnowflakeConfig.ExistingAccountConfig.URL,
+			Edition:     s.cfg.SnowflakeConfig.ExistingAccountConfig.Edition,
+			Region:      s.cfg.SnowflakeConfig.ExistingAccountConfig.Region,
+			AdminRSAKey: privateKey,
+		}
+	}
+
+	if err := validate.Struct(resolvedAccount); err != nil {
+		return nil, errors.Wrap(err, "failed to validate resolved Snowflake account")
+	}
+
+	return resolvedAccount, nil
+}
+
+// Uses orgadmin (provided with RSA key) to create a new account whose first admin user is
+// PANTHERACCOUNTADMIN with a newly generated RSA key.
+func (s *SnowflakeSetup) createSnowflakeAccount() (*ResolvedSnowflakeAcccount, error) {
+	snow := AccountCreate{}
+
+	if err := snow.Connect(s.ctx, s.cfg.SnowflakeConfig.NewAccountConfig.OrgConfig); err != nil {
+		return nil, errors.Wrap(err, "failed to connect to Snowflake")
+	}
+	defer func() {
+		if err := snow.Close(); err != nil {
+			log.Fatalf("failed to close Snowflake connection: %v\n", err)
+		}
+	}()
+
+	createAcctRes, err := snow.CreateNewSnowflakeAccount(s.cfg.SnowflakeConfig.NewAccountConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create new Snowflake account")
+	}
+
+	return createAcctRes, nil
+}
+
+// Creates a type=person admin user for the customer based on the provided config.
+func (s *SnowflakeSetup) setupSnowflakeAdmin(
+	createAcctRes *ResolvedSnowflakeAcccount,
+) error {
+	snowAcctSetup := AccountSetup{}
+	if err := snowAcctSetup.Connect(s.ctx, createAcctRes); err != nil {
+		return errors.Wrap(err, "failed to connect to new Snowflake account")
+	}
+	defer func() {
+		if err := snowAcctSetup.Close(); err != nil {
+			log.Fatalf("failed to close Snowflake account setup: %v\n", err)
+		}
+	}()
+
+	if err := snowAcctSetup.SetupCustomerAccountAdminUser(s.cfg.SnowflakeConfig.NewAccountConfig); err != nil {
+		return errors.Wrap(err, "failed to setup Panther account admin user")
+	}
+	return nil
+}

--- a/pkg/cloudconnected/snowflake/types.go
+++ b/pkg/cloudconnected/snowflake/types.go
@@ -7,19 +7,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-type CreateAccountResult struct {
+type ResolvedSnowflakeAcccount struct {
+	AccountName       string          `json:"accountName"       validate:"required"`
+	URL               string          `json:"url"               validate:"required,url"`
+	Edition           string          `json:"edition"           validate:"required"`
+	Region            string          `json:"region"            validate:"required"`
+	AdminRSAKey       *rsa.PrivateKey `json:"-"                 validate:"required"`
 	AccountLocator    string          `json:"accountLocator"`
 	AccountLocatorURL string          `json:"accountLocatorURL"`
-	AccountName       string          `json:"accountName"`
-	URL               string          `json:"url"`
-	Edition           string          `json:"edition"`
 	RegionGroup       string          `json:"regionGroup"`
 	Cloud             string          `json:"cloud"`
-	Region            string          `json:"region"`
-	AdminRSAKey       *rsa.PrivateKey `json:"-"`
 }
 
-func (c CreateAccountResult) GetAWSRegion() string {
+func (c ResolvedSnowflakeAcccount) GetAWSRegion() string {
 	lowered := strings.ToLower(c.Region)
 	stripped := strings.TrimPrefix(lowered, "aws_")
 	toDashes := strings.ReplaceAll(stripped, "_", "-")
@@ -35,7 +35,7 @@ func (c CreateAccountResult) GetAWSRegion() string {
 // In this context, "fully qualified" means the first subdomain is in the format
 // "<org name>-<account name>". The AccountName returned by Snowflake is just
 // "<account name>".
-func (c CreateAccountResult) GetFullyQualifiedAccountName() (string, error) {
+func (c ResolvedSnowflakeAcccount) GetFullyQualifiedAccountName() (string, error) {
 	// Remove protocol prefix if present
 	urlParts := strings.Split(c.URL, "://")
 	hostPart := c.URL

--- a/pkg/cloudconnected/snowflake/types.go
+++ b/pkg/cloudconnected/snowflake/types.go
@@ -8,15 +8,17 @@ import (
 )
 
 type ResolvedSnowflakeAcccount struct {
-	AccountName       string          `json:"accountName"       validate:"required"`
-	URL               string          `json:"url"               validate:"required,url"`
-	Edition           string          `json:"edition"           validate:"required"`
-	Region            string          `json:"region"            validate:"required"`
-	AdminRSAKey       *rsa.PrivateKey `json:"-"                 validate:"required"`
-	AccountLocator    string          `json:"accountLocator"`
-	AccountLocatorURL string          `json:"accountLocatorURL"`
-	RegionGroup       string          `json:"regionGroup"`
-	Cloud             string          `json:"cloud"`
+	AccountName string          `json:"accountName" validate:"required"`
+	URL         string          `json:"url"         validate:"required,url"`
+	Edition     string          `json:"edition"     validate:"required"`
+	Region      string          `json:"region"      validate:"required"`
+	AdminRSAKey *rsa.PrivateKey `json:"-"           validate:"required"`
+
+	// optional fields
+	AccountLocator    string `json:"accountLocator"`
+	AccountLocatorURL string `json:"accountLocatorURL"`
+	RegionGroup       string `json:"regionGroup"`
+	Cloud             string `json:"cloud"`
 }
 
 func (c ResolvedSnowflakeAcccount) GetAWSRegion() string {

--- a/pkg/cloudconnected/snowflake/types.go
+++ b/pkg/cloudconnected/snowflake/types.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	PantherAccountAdminUserName = "PANTHERACCOUNTADMIN"
+)
+
 type ResolvedSnowflakeAcccount struct {
 	AccountName string          `json:"accountName" validate:"required"`
 	URL         string          `json:"url"         validate:"required,url"`

--- a/pkg/cloudconnected/snowflake/types_test.go
+++ b/pkg/cloudconnected/snowflake/types_test.go
@@ -37,7 +37,7 @@ func TestGetFullyQualifiedAccountName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CreateAccountResult{URL: tt.url}
+			result := ResolvedSnowflakeAcccount{URL: tt.url}
 			got, _ := result.GetFullyQualifiedAccountName()
 			if got != tt.expected {
 				t.Errorf("GetFullyQualifiedAccountName() = %v, want %v", got, tt.expected)

--- a/pkg/cloudconnected/snowflake/util.go
+++ b/pkg/cloudconnected/snowflake/util.go
@@ -1,9 +1,12 @@
 package snowflake
 
 import (
+	"context"
+	"database/sql"
 	"log"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/snowflakedb/gosnowflake"
 
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/config"
@@ -30,4 +33,27 @@ func tryEnableSnowflakeDebugLogging() {
 	if os.Getenv("SNOWFLAKE_DEBUG") != "" {
 		_ = gosnowflake.GetLogger().SetLogLevel("debug")
 	}
+}
+
+func openSnowflakeAccountConnection(ctx context.Context, dsn string) (*sql.DB, error) {
+	tryEnableSnowflakeDebugLogging()
+
+	util.LogDebugf("Connecting to Snowflake with DSN: %s", dsn)
+
+	db, err := sql.Open("snowflake", dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open connection")
+	}
+
+	// Test the connection to make sure it's actually valid.
+	if err := db.Ping(); err != nil {
+		return nil, errors.Wrap(err, "failed to ping database")
+	}
+
+	util.LogDebugf("Successfully connected to Snowflake account (%s)", dsn)
+	return db, nil
+}
+
+func OpenSnowflakeAccountConnection(ctx context.Context, dsn string) (*sql.DB, error) {
+	return openSnowflakeAccountConnection(ctx, dsn)
 }

--- a/pkg/cloudconnected/snowflake/validate.go
+++ b/pkg/cloudconnected/snowflake/validate.go
@@ -1,0 +1,5 @@
+package snowflake
+
+import "github.com/go-playground/validator/v10"
+
+var validate *validator.Validate = validator.New(validator.WithRequiredStructEnabled())

--- a/pkg/state/db.go
+++ b/pkg/state/db.go
@@ -14,8 +14,10 @@ const (
 	createTableSQL = `
 	CREATE TABLE IF NOT EXISTS execution_state (
 		config_hash TEXT PRIMARY KEY,
-		snowflake_admin_username TEXT,
-		snowflake_account_details JSON,
+		snowflake_account_name TEXT,
+		snowflake_account_url TEXT,
+		snowflake_edition TEXT,
+		snowflake_region TEXT,
 		aws_panther_deployment_role_deployed BOOLEAN,
 		aws_readiness_bootstrap_tools_deployed BOOLEAN,
 		aws_readiness_check_succeeded BOOLEAN,
@@ -72,8 +74,10 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 	query := `
 		SELECT
 			config_hash,
-			snowflake_admin_username,
-			snowflake_account_details,
+			snowflake_account_name,
+			snowflake_account_url,
+			snowflake_edition,
+			snowflake_region,
 			aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded,
@@ -88,8 +92,10 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 	row := &Row{}
 	err := d.db.QueryRow(query, configHash).Scan(
 		&row.ConfigHash,
-		&row.SnowflakeAdminUsername,
-		&row.SnowflakeAccountDetails,
+		&row.SnowflakeAccountName,
+		&row.SnowflakeAccountURL,
+		&row.SnowflakeEdition,
+		&row.SnowflakeRegion,
 		&row.AWSPantherDeploymentRoleDeployed,
 		&row.AWSReadinessBootstrapToolsDeployed,
 		&row.AWSReadinessCheckSucceeded,
@@ -152,8 +158,10 @@ func (d *DB) SaveState(row *Row) error {
 	query := `
 		INSERT INTO execution_state (
 			config_hash,
-			snowflake_admin_username,
-			snowflake_account_details,
+			snowflake_account_name,
+			snowflake_account_url,
+			snowflake_edition,
+			snowflake_region,
 			aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded,
@@ -162,10 +170,11 @@ func (d *DB) SaveState(row *Row) error {
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
 			aws_certificates_results
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(config_hash) DO UPDATE SET
-			snowflake_admin_username = excluded.snowflake_admin_username,
-			snowflake_account_details = excluded.snowflake_account_details,
+			snowflake_account_name = excluded.snowflake_account_name,
+			snowflake_account_url = excluded.snowflake_account_url,
+			snowflake_edition = excluded.snowflake_edition,
 			aws_panther_deployment_role_deployed = excluded.aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed = excluded.aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded = excluded.aws_readiness_check_succeeded,
@@ -178,8 +187,10 @@ func (d *DB) SaveState(row *Row) error {
 	_, err := d.db.Exec(
 		query,
 		row.ConfigHash,
-		row.SnowflakeAdminUsername,
-		row.SnowflakeAccountDetails,
+		row.SnowflakeAccountName,
+		row.SnowflakeAccountURL,
+		row.SnowflakeEdition,
+		row.SnowflakeRegion,
 		row.AWSPantherDeploymentRoleDeployed,
 		row.AWSReadinessBootstrapToolsDeployed,
 		row.AWSReadinessCheckSucceeded,

--- a/pkg/state/db.go
+++ b/pkg/state/db.go
@@ -15,7 +15,6 @@ const (
 	CREATE TABLE IF NOT EXISTS execution_state (
 		config_hash TEXT PRIMARY KEY,
 		snowflake_admin_username TEXT,
-		snowflake_admin_password TEXT,
 		snowflake_account_details JSON,
 		aws_panther_deployment_role_deployed BOOLEAN,
 		aws_readiness_bootstrap_tools_deployed BOOLEAN,
@@ -74,7 +73,6 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 		SELECT
 			config_hash,
 			snowflake_admin_username,
-			snowflake_admin_password,
 			snowflake_account_details,
 			aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed,
@@ -91,7 +89,6 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 	err := d.db.QueryRow(query, configHash).Scan(
 		&row.ConfigHash,
 		&row.SnowflakeAdminUsername,
-		&row.SnowflakeAdminPassword,
 		&row.SnowflakeAccountDetails,
 		&row.AWSPantherDeploymentRoleDeployed,
 		&row.AWSReadinessBootstrapToolsDeployed,
@@ -156,7 +153,6 @@ func (d *DB) SaveState(row *Row) error {
 		INSERT INTO execution_state (
 			config_hash,
 			snowflake_admin_username,
-			snowflake_admin_password,
 			snowflake_account_details,
 			aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed,
@@ -166,10 +162,9 @@ func (d *DB) SaveState(row *Row) error {
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
 			aws_certificates_results
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(config_hash) DO UPDATE SET
 			snowflake_admin_username = excluded.snowflake_admin_username,
-			snowflake_admin_password = excluded.snowflake_admin_password,
 			snowflake_account_details = excluded.snowflake_account_details,
 			aws_panther_deployment_role_deployed = excluded.aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed = excluded.aws_readiness_bootstrap_tools_deployed,
@@ -184,7 +179,6 @@ func (d *DB) SaveState(row *Row) error {
 		query,
 		row.ConfigHash,
 		row.SnowflakeAdminUsername,
-		row.SnowflakeAdminPassword,
 		row.SnowflakeAccountDetails,
 		row.AWSPantherDeploymentRoleDeployed,
 		row.AWSReadinessBootstrapToolsDeployed,

--- a/pkg/state/db_test.go
+++ b/pkg/state/db_test.go
@@ -58,7 +58,7 @@ func TestDB(t *testing.T) {
 		// Create a new state
 		newState := &Row{
 			ConfigHash:                       configHash,
-			SnowflakeAdminUsername:           "testuser",
+			SnowflakeAccountName:             "testaccount",
 			AWSPantherDeploymentRoleDeployed: true,
 		}
 
@@ -71,11 +71,11 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, retrievedState)
 		assert.Equal(t, configHash, retrievedState.ConfigHash)
-		assert.Equal(t, "testuser", retrievedState.SnowflakeAdminUsername)
+		assert.Equal(t, "testaccount", retrievedState.SnowflakeAccountName)
 		assert.True(t, retrievedState.AWSPantherDeploymentRoleDeployed)
 
 		// Update the state
-		newState.SnowflakeAdminUsername = "updateduser"
+		newState.SnowflakeAccountName = "updatedaccount"
 		err = db.SaveState(newState)
 		require.NoError(t, err)
 
@@ -83,7 +83,7 @@ func TestDB(t *testing.T) {
 		retrievedState, err = db.GetState(configHash)
 		require.NoError(t, err)
 		require.NotNil(t, retrievedState)
-		assert.Equal(t, "updateduser", retrievedState.SnowflakeAdminUsername)
+		assert.Equal(t, "updatedaccount", retrievedState.SnowflakeAccountName)
 	})
 
 	// Test multiple configs
@@ -102,13 +102,13 @@ func TestDB(t *testing.T) {
 		hash2 := "hash2"
 
 		state1 := &Row{
-			ConfigHash:             hash1,
-			SnowflakeAdminUsername: "user1",
+			ConfigHash:           hash1,
+			SnowflakeAccountName: "account1",
 		}
 
 		state2 := &Row{
-			ConfigHash:             hash2,
-			SnowflakeAdminUsername: "user2",
+			ConfigHash:           hash2,
+			SnowflakeAccountName: "account2",
 		}
 
 		// Save both states
@@ -122,11 +122,11 @@ func TestDB(t *testing.T) {
 		retrieved1, err := db.GetState(hash1)
 		require.NoError(t, err)
 		require.NotNil(t, retrieved1)
-		assert.Equal(t, "user1", retrieved1.SnowflakeAdminUsername)
+		assert.Equal(t, "account1", retrieved1.SnowflakeAccountName)
 
 		retrieved2, err := db.GetState(hash2)
 		require.NoError(t, err)
 		require.NotNil(t, retrieved2)
-		assert.Equal(t, "user2", retrieved2.SnowflakeAdminUsername)
+		assert.Equal(t, "account2", retrieved2.SnowflakeAccountName)
 	})
 }

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -69,9 +69,9 @@ func (m *Manager) GetState() *Row {
 }
 
 // UpdateSnowflakeState updates the Snowflake-related state
-func (m *Manager) UpdateSnowflakeState(username string, accountDetails snowflake.CreateAccountResult) error {
+func (m *Manager) UpdateSnowflakeState(username string, accountDetails *snowflake.ResolvedSnowflakeAcccount) error {
 	m.state.SnowflakeAdminUsername = username
-	m.state.SnowflakeAccountDetails = SnowflakeAccountDetails{CreateAccountResult: accountDetails}
+	m.state.SnowflakeAccountDetails = SnowflakeAccountDetails{ResolvedSnowflakeAcccount: *accountDetails}
 	return m.SaveState()
 }
 

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -69,9 +69,8 @@ func (m *Manager) GetState() *Row {
 }
 
 // UpdateSnowflakeState updates the Snowflake-related state
-func (m *Manager) UpdateSnowflakeState(username string, accountDetails *snowflake.ResolvedSnowflakeAcccount) error {
-	m.state.SnowflakeAdminUsername = username
-	m.state.SnowflakeAccountDetails = SnowflakeAccountDetails{ResolvedSnowflakeAcccount: *accountDetails}
+func (m *Manager) UpdateSnowflakeState(accountDetails *snowflake.ResolvedSnowflakeAcccount) error {
+	m.state.PopulateSnowflakeAccountDetails(accountDetails)
 	return m.SaveState()
 }
 

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -20,7 +20,7 @@ type Manager struct {
 }
 
 // NewManager creates a new state manager for a given config
-func NewManager(cfg config.Config) (*Manager, error) {
+func NewManager(cfg *config.Config) (*Manager, error) {
 	// Calculate config hash
 	cfgBytes, err := json.Marshal(cfg)
 	if err != nil {

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -69,9 +69,8 @@ func (m *Manager) GetState() *Row {
 }
 
 // UpdateSnowflakeState updates the Snowflake-related state
-func (m *Manager) UpdateSnowflakeState(username, password string, accountDetails snowflake.CreateAccountResult) error {
+func (m *Manager) UpdateSnowflakeState(username string, accountDetails snowflake.CreateAccountResult) error {
 	m.state.SnowflakeAdminUsername = username
-	m.state.SnowflakeAdminPassword = password
 	m.state.SnowflakeAccountDetails = SnowflakeAccountDetails{CreateAccountResult: accountDetails}
 	return m.SaveState()
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -364,7 +364,7 @@ func TestSnowflakeState(t *testing.T) {
 		// Create mock Snowflake account result
 		accountDetails := &snowflake.ResolvedSnowflakeAcccount{
 			AccountName: "PANTHER_TEST",
-			Region:      "us-west-2.aws",
+			Region:      "aws_us_west_2",
 			URL:         "https://panther_test-account123.snowflakecomputing.com",
 			AdminRSAKey: privateKey,
 		}
@@ -376,7 +376,7 @@ func TestSnowflakeState(t *testing.T) {
 		// Verify state
 		state := manager.GetState()
 		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountName)
-		assert.Equal(t, accountDetails.Region, state.SnowflakeEdition)
+		assert.Equal(t, accountDetails.Region, state.SnowflakeRegion)
 		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountURL)
 	})
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -362,7 +362,7 @@ func TestSnowflakeState(t *testing.T) {
 		require.NotNil(t, privateKey)
 
 		// Create mock Snowflake account result
-		accountDetails := snowflake.CreateAccountResult{
+		accountDetails := &snowflake.ResolvedSnowflakeAcccount{
 			AccountName: "PANTHER_TEST",
 			Region:      "us-west-2.aws",
 			URL:         "https://panther_test-account123.snowflakecomputing.com",
@@ -376,9 +376,9 @@ func TestSnowflakeState(t *testing.T) {
 		// Verify state
 		state := manager.GetState()
 		assert.Equal(t, "testuser", state.SnowflakeAdminUsername)
-		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountDetails.CreateAccountResult.AccountName)
-		assert.Equal(t, accountDetails.Region, state.SnowflakeAccountDetails.CreateAccountResult.Region)
-		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountDetails.CreateAccountResult.URL)
-		assert.NotNil(t, state.SnowflakeAccountDetails.CreateAccountResult.AdminRSAKey)
+		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.AccountName)
+		assert.Equal(t, accountDetails.Region, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.Region)
+		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.URL)
+		assert.NotNil(t, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.AdminRSAKey)
 	})
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -365,6 +365,7 @@ func TestSnowflakeState(t *testing.T) {
 		accountDetails := &snowflake.ResolvedSnowflakeAcccount{
 			AccountName: "PANTHER_TEST",
 			Region:      "aws_us_west_2",
+			Edition:     "ENTERPRISE",
 			URL:         "https://panther_test-account123.snowflakecomputing.com",
 			AdminRSAKey: privateKey,
 		}
@@ -377,6 +378,7 @@ func TestSnowflakeState(t *testing.T) {
 		state := manager.GetState()
 		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountName)
 		assert.Equal(t, accountDetails.Region, state.SnowflakeRegion)
+		assert.Equal(t, accountDetails.Edition, state.SnowflakeEdition)
 		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountURL)
 	})
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -370,15 +370,13 @@ func TestSnowflakeState(t *testing.T) {
 		}
 
 		// Update Snowflake state
-		err = manager.UpdateSnowflakeState("testuser", accountDetails)
+		err = manager.UpdateSnowflakeState(accountDetails)
 		require.NoError(t, err)
 
 		// Verify state
 		state := manager.GetState()
-		assert.Equal(t, "testuser", state.SnowflakeAdminUsername)
-		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.AccountName)
-		assert.Equal(t, accountDetails.Region, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.Region)
-		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.URL)
-		assert.NotNil(t, state.SnowflakeAccountDetails.ResolvedSnowflakeAcccount.AdminRSAKey)
+		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountName)
+		assert.Equal(t, accountDetails.Region, state.SnowflakeEdition)
+		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountURL)
 	})
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -370,13 +370,12 @@ func TestSnowflakeState(t *testing.T) {
 		}
 
 		// Update Snowflake state
-		err = manager.UpdateSnowflakeState("testuser", "testpassword", accountDetails)
+		err = manager.UpdateSnowflakeState("testuser", accountDetails)
 		require.NoError(t, err)
 
 		// Verify state
 		state := manager.GetState()
 		assert.Equal(t, "testuser", state.SnowflakeAdminUsername)
-		assert.Equal(t, "testpassword", state.SnowflakeAdminPassword)
 		assert.Equal(t, accountDetails.AccountName, state.SnowflakeAccountDetails.CreateAccountResult.AccountName)
 		assert.Equal(t, accountDetails.Region, state.SnowflakeAccountDetails.CreateAccountResult.Region)
 		assert.Equal(t, accountDetails.URL, state.SnowflakeAccountDetails.CreateAccountResult.URL)

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -25,7 +25,7 @@ func TestNewManager(t *testing.T) {
 	}()
 
 	// Create a simple test config
-	cfg := config.Config{
+	cfg := &config.Config{
 		AWSConfig: config.AWSConfig{
 			AccessKeyID:     "test-access-key",
 			SecretAccessKey: "test-secret-key",
@@ -113,7 +113,7 @@ func TestStateUpdates(t *testing.T) {
 	}()
 
 	// Create a simple test config
-	cfg := config.Config{
+	cfg := &config.Config{
 		AWSConfig: config.AWSConfig{
 			AccessKeyID:     "test-access-key",
 			SecretAccessKey: "test-secret-key",
@@ -339,7 +339,7 @@ func TestSnowflakeState(t *testing.T) {
 	}()
 
 	// Create a simple test config
-	cfg := config.Config{
+	cfg := &config.Config{
 		AWSConfig: config.AWSConfig{
 			AccessKeyID:     "test-access-key",
 			SecretAccessKey: "test-secret-key",

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -363,7 +363,7 @@ func TestSnowflakeState(t *testing.T) {
 
 		// Create mock Snowflake account result
 		accountDetails := &snowflake.ResolvedSnowflakeAcccount{
-			AccountName: "PANTHER_TEST",
+			AccountName: "panther_test-account123",
 			Region:      "aws_us_west_2",
 			Edition:     "ENTERPRISE",
 			URL:         "https://panther_test-account123.snowflakecomputing.com",

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -117,7 +117,6 @@ func (r *ReadinessCheckResults) Scan(value interface{}) error {
 type Row struct {
 	ConfigHash                         string `validate:"sha256"`
 	SnowflakeAdminUsername             string
-	SnowflakeAdminPassword             string
 	SnowflakeAdminRSAKey               string
 	SnowflakeAccountDetails            SnowflakeAccountDetails
 	AWSPantherDeploymentRoleDeployed   bool

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -155,7 +155,7 @@ type OutputDetails struct {
 
 // PrettyPrint outputs a human-readable format of the state to the standard logger
 // It requires a config.Config to access some information.
-func (r *Row) PrettyPrint(cfg config.Config) {
+func (r *Row) PrettyPrint(cfg *config.Config) {
 	// Get structured output data
 	output := r.createStructuredOutput(cfg)
 
@@ -225,7 +225,7 @@ func (r *Row) PrettyPrint(cfg config.Config) {
 
 // FormatJSON returns a formatted JSON string representation of the row.
 // It requires a config.Config to generate the output.
-func (r *Row) FormatJSON(cfg config.Config) (string, error) {
+func (r *Row) FormatJSON(cfg *config.Config) (string, error) {
 	// Create structured output
 	output := r.createStructuredOutput(cfg)
 
@@ -239,22 +239,22 @@ func (r *Row) FormatJSON(cfg config.Config) (string, error) {
 }
 
 // createStructuredOutput creates a structured output object with relevant information
-func (r *Row) createStructuredOutput(cfg config.Config) OutputDetails {
+func (r *Row) createStructuredOutput(cfg *config.Config) OutputDetails {
 	// Initialize the output structure
 	output := OutputDetails{
-		AWSAccountID:              cfg.AWSConfig.MustGetAWSAccountID(),
-		PantherSubdomain:          cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain,
-		DesiredPantherAccountName: cfg.NewAccountConfig.DesiredPantherAccountName,
-		AdminUserFirstName:        cfg.NewAccountConfig.AdminUserFirstName,
-		AdminUserLastName:         cfg.NewAccountConfig.AdminUserLastName,
-		AdminUsername:             cfg.NewAccountConfig.AdminUsername,
-		AdminEmail:                cfg.NewAccountConfig.AdminEmail,
-		IpAddressAllowList:        cfg.NewAccountConfig.IpAddressAllowList,
-		SnowflakeRegion:           cfg.NewAccountConfig.GetSnowflakeRegion(),
-		SnowflakeEdition:          cfg.NewAccountConfig.SnowflakeEdition,
-		PantherEdition:            cfg.NewAccountConfig.PantherEdition,
-		PantherRegion:             cfg.NewAccountConfig.PantherRegion,
-		DeploymentStatus:          make(map[string]interface{}),
+		// AWSAccountID:              cfg.AWSConfig.MustGetAWSAccountID(),
+		// PantherSubdomain:          cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain,
+		// DesiredPantherAccountName: cfg.PantherAccountConfig.DesiredPantherAccountName.DesiredPantherAccountName,
+		// AdminUserFirstName:        cfg.NewAccountConfig.AdminUserFirstName,
+		// AdminUserLastName:         cfg.NewAccountConfig.AdminUserLastName,
+		// AdminUsername:             cfg.NewAccountConfig.AdminUsername,
+		// AdminEmail:                cfg.NewAccountConfig.AdminEmail,
+		// IpAddressAllowList:        cfg.NewAccountConfig.IpAddressAllowList,
+		// SnowflakeRegion:           cfg.NewAccountConfig.GetSnowflakeRegion(),
+		// SnowflakeEdition:          cfg.NewAccountConfig.SnowflakeEdition,
+		// PantherEdition:            cfg.NewAccountConfig.PantherEdition,
+		// PantherRegion:             cfg.NewAccountConfig.PantherRegion,
+		// DeploymentStatus:          make(map[string]interface{}),
 	}
 
 	// Add certificate ARNs if available

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -12,68 +12,27 @@ import (
 
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/config"
 	"github.com/panther-labs/panther-cli/pkg/cloudconnected/snowflake"
-	"github.com/panther-labs/panther-cli/pkg/rsapem"
 )
-
-// SnowflakeAccountDetails wraps snowflake.CreateAccountResult for JSON serialization
-type SnowflakeAccountDetails struct {
-	snowflake.ResolvedSnowflakeAcccount
-}
-
-type serializedSnowflakeAccountDetails struct {
-	snowflake.ResolvedSnowflakeAcccount
-	SerializedKey string
-}
-
-// Value implements the driver.Valuer interface for JSON storage
-// and handles the RSA key with a dedicated encoder
-func (s SnowflakeAccountDetails) Value() (driver.Value, error) {
-	serializedKey, err := rsapem.EncodeRSAPEMPrivateKey(s.AdminRSAKey)
-	if err != nil {
-		return nil, errors.Wrap(err, "serializing AdminRSAKey in row Valuer")
-	}
-	return json.Marshal(serializedSnowflakeAccountDetails{
-		ResolvedSnowflakeAcccount: s.ResolvedSnowflakeAcccount,
-		SerializedKey:             serializedKey,
-	})
-}
-
-// Scan implements the sql.Scanner interface for JSON storage
-// and handles the RSA key with a dedicated decoder
-func (s *SnowflakeAccountDetails) Scan(value interface{}) error {
-	b, ok := value.([]byte)
-	if !ok {
-		return errors.New("type assertion to []byte failed")
-	}
-	x := serializedSnowflakeAccountDetails{}
-	err := json.Unmarshal(b, &x)
-	if err != nil {
-		return errors.Wrap(err, "unmarshalling SnowflakeAccountDetails")
-	}
-	s.ResolvedSnowflakeAcccount = x.ResolvedSnowflakeAcccount
-	s.AdminRSAKey, err = rsapem.ParseRSAPEMPrivateKey(x.SerializedKey)
-	return err
-}
 
 // CertificateValidationRecord represents the DNS validation details for a certificate
 type CertificateValidationRecord struct {
-	DomainName  string `json:"domainName"`
-	RecordName  string `json:"recordName"`
-	RecordValue string `json:"recordValue"`
-	RecordType  string `json:"recordType"`
+	DomainName  string `json:"domain_name"`
+	RecordName  string `json:"record_name"`
+	RecordValue string `json:"record_value"`
+	RecordType  string `json:"record_type"`
 }
 
 // CertificateRecord represents a registered certificate and its validation details
 type CertificateRecord struct {
-	CertificateArn    string                      `json:"certificateArn"`
-	ValidationDetails CertificateValidationRecord `json:"validationDetails"`
-	IsIssued          bool                        `json:"isIssued"`
+	CertificateArn    string                      `json:"certificate_arn"`
+	ValidationDetails CertificateValidationRecord `json:"validation_details"`
+	IsIssued          bool                        `json:"is_issued"`
 }
 
 // CertificateResults stores the results of certificate registration
 type CertificateResults struct {
-	PantherSubdomain  *CertificateRecord `json:"pantherSubdomain,omitempty"`
-	WildcardSubdomain *CertificateRecord `json:"wildcardSubdomain,omitempty"`
+	PantherSubdomain  *CertificateRecord `json:"panther_subdomain,omitempty"`
+	WildcardSubdomain *CertificateRecord `json:"wildcard_subdomain,omitempty"`
 }
 
 // Value implements the driver.Valuer interface for JSON storage
@@ -116,9 +75,10 @@ func (r *ReadinessCheckResults) Scan(value interface{}) error {
 
 type Row struct {
 	ConfigHash                         string `validate:"sha256"`
-	SnowflakeAdminUsername             string
-	SnowflakeAdminRSAKey               string
-	SnowflakeAccountDetails            SnowflakeAccountDetails
+	SnowflakeAccountName               string
+	SnowflakeAccountURL                string
+	SnowflakeEdition                   string
+	SnowflakeRegion                    string
 	AWSPantherDeploymentRoleDeployed   bool
 	AWSReadinessBootstrapToolsDeployed bool
 	AWSReadinessCheckSucceeded         bool
@@ -139,14 +99,14 @@ type OutputDetails struct {
 
 	AdminUserFirstName string `json:"admin_user_first_name"`
 	AdminUserLastName  string `json:"admin_user_last_name"`
-	AdminUsername      string `json:"admin_username"`
 	AdminEmail         string `json:"admin_email"`
 
-	AWSAccountID string `json:"aws_account_id"`
-
-	SnowflakeSecretARN string `json:"snowflake_secret_arn"`
-	SnowflakeRegion    string `json:"snowflake_region"`
-	SnowflakeEdition   string `json:"snowflake_edition"`
+	SnowflakeSecretARN   string `json:"snowflake_secret_arn,omitempty"`
+	SnowflakeAccountName string `json:"snowflake_account_name,omitempty"`
+	SnowflakeAccountURL  string `json:"snowflake_account_url,omitempty"`
+	SnowflakeEdition     string `json:"snowflake_edition,omitempty"`
+	SnowflakeRegion      string `json:"snowflake_region,omitempty"`
+	AWSAccountID         string `json:"aws_account_id"`
 
 	PantherCertificateARN  string                 `json:"panther_certificate_arn,omitempty"`
 	WildcardCertificateARN string                 `json:"wildcard_certificate_arn,omitempty"`
@@ -164,11 +124,9 @@ func (r *Row) PrettyPrint(cfg *config.Config) {
 
 	// Print Snowflake Account Details section
 	log.Printf("Snowflake Account Details:\n")
-	log.Printf("  Account Name: %s\n", r.SnowflakeAccountDetails.AccountName)
-	log.Printf("  URL: %s\n", r.SnowflakeAccountDetails.URL)
-	log.Printf("  Admin Username: %s\n", r.SnowflakeAdminUsername)
-	log.Printf("  Region: %s\n", output.SnowflakeRegion)
-	log.Printf("  Edition: %s\n", output.SnowflakeEdition)
+	log.Printf("  Account Name: %s\n", r.SnowflakeAccountName)
+	log.Printf("  URL: %s\n", r.SnowflakeAccountURL)
+	log.Printf("  Edition: %s\n", r.SnowflakeEdition)
 
 	// Print AWS Account ID if available
 	if output.AWSAccountID != "" {
@@ -223,6 +181,21 @@ func (r *Row) PrettyPrint(cfg *config.Config) {
 	}
 }
 
+func (r *Row) PopulateSnowflakeAccountDetails(accountDetails *snowflake.ResolvedSnowflakeAcccount) {
+	r.SnowflakeAccountName = accountDetails.AccountName
+	r.SnowflakeAccountURL = accountDetails.URL
+	r.SnowflakeEdition = accountDetails.Edition
+}
+
+func (r *Row) RenderNonSensitiveSnowflakeAccountDetails() *snowflake.ResolvedSnowflakeAcccount {
+	return &snowflake.ResolvedSnowflakeAcccount{
+		AccountName: r.SnowflakeAccountName,
+		URL:         r.SnowflakeAccountURL,
+		Edition:     r.SnowflakeEdition,
+		Region:      r.SnowflakeRegion,
+	}
+}
+
 // FormatJSON returns a formatted JSON string representation of the row.
 // It requires a config.Config to generate the output.
 func (r *Row) FormatJSON(cfg *config.Config) (string, error) {
@@ -242,19 +215,19 @@ func (r *Row) FormatJSON(cfg *config.Config) (string, error) {
 func (r *Row) createStructuredOutput(cfg *config.Config) OutputDetails {
 	// Initialize the output structure
 	output := OutputDetails{
-		// AWSAccountID:              cfg.AWSConfig.MustGetAWSAccountID(),
-		// PantherSubdomain:          cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain,
-		// DesiredPantherAccountName: cfg.PantherAccountConfig.DesiredPantherAccountName.DesiredPantherAccountName,
-		// AdminUserFirstName:        cfg.NewAccountConfig.AdminUserFirstName,
-		// AdminUserLastName:         cfg.NewAccountConfig.AdminUserLastName,
-		// AdminUsername:             cfg.NewAccountConfig.AdminUsername,
-		// AdminEmail:                cfg.NewAccountConfig.AdminEmail,
-		// IpAddressAllowList:        cfg.NewAccountConfig.IpAddressAllowList,
-		// SnowflakeRegion:           cfg.NewAccountConfig.GetSnowflakeRegion(),
-		// SnowflakeEdition:          cfg.NewAccountConfig.SnowflakeEdition,
-		// PantherEdition:            cfg.NewAccountConfig.PantherEdition,
-		// PantherRegion:             cfg.NewAccountConfig.PantherRegion,
-		// DeploymentStatus:          make(map[string]interface{}),
+		AWSAccountID:              cfg.AWSConfig.MustGetAWSAccountID(),
+		PantherSubdomain:          cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain,
+		DesiredPantherAccountName: cfg.PantherAccountConfig.DesiredAccountName,
+		AdminUserFirstName:        cfg.PantherAccountConfig.AdminUserFirstName,
+		AdminUserLastName:         cfg.PantherAccountConfig.AdminUserLastName,
+		AdminEmail:                cfg.PantherAccountConfig.AdminEmail,
+		IpAddressAllowList:        cfg.PantherAccountConfig.IpAddressAllowList,
+		SnowflakeAccountName:      r.SnowflakeAccountName,
+		SnowflakeAccountURL:       r.SnowflakeAccountURL,
+		SnowflakeEdition:          r.SnowflakeEdition,
+		PantherEdition:            cfg.PantherAccountConfig.Edition,
+		PantherRegion:             cfg.PantherAccountConfig.Region,
+		DeploymentStatus:          make(map[string]interface{}),
 	}
 
 	// Add certificate ARNs if available

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -185,6 +185,7 @@ func (r *Row) PopulateSnowflakeAccountDetails(accountDetails *snowflake.Resolved
 	r.SnowflakeAccountName = accountDetails.AccountName
 	r.SnowflakeAccountURL = accountDetails.URL
 	r.SnowflakeEdition = accountDetails.Edition
+	r.SnowflakeRegion = accountDetails.Region
 }
 
 func (r *Row) RenderNonSensitiveSnowflakeAccountDetails() *snowflake.ResolvedSnowflakeAcccount {

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -182,7 +182,11 @@ func (r *Row) PrettyPrint(cfg *config.Config) {
 }
 
 func (r *Row) PopulateSnowflakeAccountDetails(accountDetails *snowflake.ResolvedSnowflakeAcccount) {
-	r.SnowflakeAccountName = accountDetails.AccountName
+	fullyQualifiedAccountName, err := accountDetails.GetFullyQualifiedAccountName()
+	if err != nil {
+		log.Printf("failed to get fully qualified account name, error='%s'", err)
+	}
+	r.SnowflakeAccountName = fullyQualifiedAccountName
 	r.SnowflakeAccountURL = accountDetails.URL
 	r.SnowflakeEdition = accountDetails.Edition
 	r.SnowflakeRegion = accountDetails.Region

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -17,11 +17,11 @@ import (
 
 // SnowflakeAccountDetails wraps snowflake.CreateAccountResult for JSON serialization
 type SnowflakeAccountDetails struct {
-	snowflake.CreateAccountResult
+	snowflake.ResolvedSnowflakeAcccount
 }
 
 type serializedSnowflakeAccountDetails struct {
-	snowflake.CreateAccountResult
+	snowflake.ResolvedSnowflakeAcccount
 	SerializedKey string
 }
 
@@ -33,8 +33,8 @@ func (s SnowflakeAccountDetails) Value() (driver.Value, error) {
 		return nil, errors.Wrap(err, "serializing AdminRSAKey in row Valuer")
 	}
 	return json.Marshal(serializedSnowflakeAccountDetails{
-		CreateAccountResult: s.CreateAccountResult,
-		SerializedKey:       serializedKey,
+		ResolvedSnowflakeAcccount: s.ResolvedSnowflakeAcccount,
+		SerializedKey:             serializedKey,
 	})
 }
 
@@ -50,7 +50,7 @@ func (s *SnowflakeAccountDetails) Scan(value interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "unmarshalling SnowflakeAccountDetails")
 	}
-	s.CreateAccountResult = x.CreateAccountResult
+	s.ResolvedSnowflakeAcccount = x.ResolvedSnowflakeAcccount
 	s.AdminRSAKey, err = rsapem.ParseRSAPEMPrivateKey(x.SerializedKey)
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Zac Brown <zacbrown@users.noreply.github.com><!--
This repo is made possible by contributors like you. Thank you.
Please include a high level overview of the changes made
-->

## Overview

<!-- What did you add? -->
- added ability to specify existing snowflake account

<!-- What did you change? -->
- changed configuration format to make configuration easier
- use fewer duplicate fields (edition, region) across different sections of configs

<!-- What did you remove? -->
- removed...

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [x] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: https://panther-labs.atlassian.net/browse/EPD-2992