### PR TITLE
Implement a YAML Schema and apply it to the config.

### DIFF
--- a/.cursor/rules/code-style-golang.mdc
+++ b/.cursor/rules/code-style-golang.mdc
@@ -3,7 +3,6 @@ description: Go code style and best practices
 globs: *.go
 alwaysApply: true
 ---
-
 <rule>
   - type: event
     pattern: "cursor_suggestion"
@@ -17,6 +16,8 @@ actions:
         message: "Error handling should include context"
       - pattern: "(?s).*var\\s+\\w+\\s+interface{}"
         message: "Avoid empty interface unless absolutely necessary"
+      - pattern: "errors\\.Wrap\\(\\s*err\\s*,\\s*fmt\\.Sprintf\\("
+        message: "Use errors.Wrapf instead of errors.Wrap with fmt.Sprintf"
     message: |
       Follow these Go code style guidelines:
 
@@ -25,25 +26,26 @@ actions:
          - Package name matches directory name
          - Internal packages in 'internal/'
          - Shared packages in 'pkg/'
-      
+
       2. Error Handling:
          - Use pkg/errors for error wrapping
          - Return errors as last return value
          - Always handle errors explicitly
          - Use error variables for sentinel errors
-      
+         - Use `errors.Wrapf` instead of `errors.Wrap(err, fmt.Sprintf(...))`
+
       3. Interface Design:
          - Keep interfaces small
          - Define interfaces at use site
          - Use io.Reader/Writer where applicable
          - Prefer composition over inheritance
-      
+
       4. Concurrency:
          - Use channels for communication
          - Mutex for simple state protection
          - Document concurrent access
          - Close channels when done
-      
+
       5. Testing:
          - Table-driven tests
          - Use testify for assertions
@@ -60,7 +62,7 @@ examples:
     output: |
       func processData(data []byte) error {
           if len(data) == 0 {
-              return fmt.Errorf("processData: empty data")
+              return errors.Errorf("processData: empty data")
           }
           // process with error handling
           return nil
@@ -72,7 +74,7 @@ examples:
       }
     output: |
       if err != nil {
-          return fmt.Errorf("failed to process data: %w", err)
+          return errors.Errorf("failed to process data: %w", err)
       }
   - input: |
       func TestSomething(t *testing.T) {
@@ -91,4 +93,4 @@ metadata:
   version: "1.0"
   category: code_style
   maintainer: Panther Labs Inc.
-</rule> 
+</rule>

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -53,15 +53,23 @@ func main() {
 	if currentState.SnowflakeAccountName == "" {
 		// Setup Snowflake if not already done
 		snowflakeSetup := snowflake.NewSnowflakeSetup(ctx, cfg)
-		resolvedSnowflakeAccount, err = snowflakeSetup.Run()
+		resolvedSnowflakeAccount, err = snowflakeSetup.CreateOrResolveAccount()
 		if err != nil {
 			log.Fatalf("failed to setup Snowflake: %v\n", err)
 		}
 
-		if err := stateManager.UpdateSnowflakeState(resolvedSnowflakeAccount); err != nil {
+		if err := stateManager.UpdateSnowflakeState(resolvedSnowflakeAccount, false); err != nil {
 			log.Fatalf("failed to update Snowflake state: %v\n", err)
 		}
 		log.Println("Successfully resolved Snowflake account")
+
+		if err := snowflakeSetup.SetupAccount(resolvedSnowflakeAccount); err != nil {
+			log.Fatalf("failed to setup Snowflake account: %v\n", err)
+		}
+
+		if err := stateManager.UpdateSnowflakeState(resolvedSnowflakeAccount, true); err != nil {
+			log.Fatalf("failed to update Snowflake state: %v\n", err)
+		}
 	} else {
 		log.Println("Using existing Snowflake account details")
 

--- a/example-config-existing-snowflake-acct.yml
+++ b/example-config-existing-snowflake-acct.yml
@@ -1,6 +1,7 @@
 AWSConfig:
   AccessKeyID: <YOUR AWS ACCESS KEY ID>
   SecretAccessKey: <YOUR AWS SECRET ACCESS KEY>
+  SessionToken: <YOUR AWS SESSION TOKEN> # This is optional.
   CloudFormationConfig:
     DeploymentRoleName: PantherDeploymentRole # WE RECOMMEND USING THIS VALUE
     IdentityAccountId: <ASK FOR THIS INFORMATION FROM PANTHER>

--- a/example-config-new-snowflake-acct.yml
+++ b/example-config-new-snowflake-acct.yml
@@ -1,6 +1,7 @@
 AWSConfig:
   AccessKeyID: <YOUR AWS ACCESS KEY ID>
   SecretAccessKey: <YOUR AWS SECRET ACCESS KEY>
+  SessionToken: <YOUR AWS SESSION TOKEN> # This is optional.
   CloudFormationConfig:
     DeploymentRoleName: PantherDeploymentRole # WE RECOMMEND USING THIS VALUE
     IdentityAccountId: <ASK FOR THIS INFORMATION FROM PANTHER>

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/pkg/errors v0.9.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/snowflakedb/gosnowflake v1.13.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/text v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dvsekhvalnov/jose2go v1.8.0 h1:LqkkVKAlHFfH9LOEl5fe4p/zL02OhWE7pCufMBG2jLA=
 github.com/dvsekhvalnov/jose2go v1.8.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
@@ -150,6 +152,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/snowflakedb/gosnowflake v1.13.1 h1:Bye6NpnoPywIFPtAxCxtlUsdDN2idj3mBtK7tVjoCmY=

--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -1,15 +1,22 @@
 package config
 
 import (
-	"errors"
+	_ "embed"
 	"log"
 	"os"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/k0kubun/pp/v3"
 	"github.com/mcuadros/go-defaults"
+	"github.com/panther-labs/panther-cli/pkg/util"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gopkg.in/yaml.v3"
+
+	"github.com/pkg/errors"
 )
+
+//go:embed schema.yaml
+var schemaBytes []byte
 
 type Config struct {
 	AWSConfig            AWSConfig            `yaml:"AWSConfig"            validate:"required"`
@@ -17,44 +24,94 @@ type Config struct {
 	PantherAccountConfig PantherAccountConfig `yaml:"PantherAccountConfig" validate:"required"`
 }
 
-func (c Config) validate() error {
-	return validate.Struct(c)
-}
-
 func NewConfigFromPath(path string) (*Config, error) {
 	cfg := &Config{}
 
-	file, err := os.Open(path)
+	if err := validateConfigSchema(path); err != nil {
+		return nil, errors.Wrapf(err, "config schema validation failed")
+	}
+
+	configAsStr, err := readFileContent(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read config file '%s'", path)
 	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			log.Fatalf("failed to close config file: %v\n", err)
-		}
-	}()
+	configBytes := []byte(configAsStr)
 
-	decoder := yaml.NewDecoder(file)
-	if err := decoder.Decode(&cfg); err != nil {
-		return nil, err
+	var rawConfigData interface{}
+	if err := yaml.Unmarshal([]byte(configBytes), &rawConfigData); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse config file '%s' as YAML", path)
 	}
 
-	// initialize defaults within the config, this is recursive
-	defaults.SetDefaults(cfg)
+	if err := yaml.Unmarshal(configBytes, &cfg); err != nil {
+		// This should ideally not happen if YAML parsing and schema validation passed,
+		// but good to have as a safeguard.
+		return nil, errors.Wrapf(err, "failed to unmarshal config into struct after schema validation")
+	}
 
-	// We need the region, but the customer doesn't need to provide it twice. It
-	// should always match up between the two configs.
+	defaults.SetDefaults(cfg) // initialize defaults within the config
+
+	// Setup dependent fields
 	cfg.setupAWSConfig()
-
 	if err := cfg.setupSnowflakeConfig(); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed during Snowflake config setup")
 	}
 
-	if err := cfg.validateConfig(); err != nil {
-		return nil, err
+	if err := cfg.validateConfigStruct(); err != nil {
+		return nil, errors.Wrapf(err, "config validation failed")
 	}
 
+	log.Printf("Config loaded and validated successfully from '%s'", path)
 	return cfg, nil
+}
+
+// validateConfigSchema validates the config file against the schema.
+// It's not a receiver because it's used before we've de-seriealized the
+// the config into a struct.
+func validateConfigSchema(path string) (err error) {
+	configAsStr, err := readFileContent(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read config file '%s'", path)
+	}
+	configBytes := []byte(configAsStr)
+
+	var rawConfigData interface{}
+	if err := yaml.Unmarshal([]byte(configBytes), &rawConfigData); err != nil {
+		return errors.Wrapf(err, "failed to parse config file '%s' as YAML", path)
+	}
+
+	var schemaAsUnmarshalledYAML interface{}
+	if err := yaml.Unmarshal(schemaBytes, &schemaAsUnmarshalledYAML); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal schema as YAML")
+	}
+
+	compiler := jsonschema.NewCompiler()
+	const schemaPath = "./schema.yaml" // Adjust path if necessary
+
+	// Register the schema file with the compiler using the reader
+	if err := compiler.AddResource(schemaPath, schemaAsUnmarshalledYAML); err != nil {
+		return errors.Wrapf(err, "failed to add schema resource '%s'", schemaPath)
+	}
+	schema, err := compiler.Compile(schemaPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load or compile schema '%s'", schemaPath)
+	}
+
+	if err := schema.Validate(rawConfigData); err != nil {
+		// Provide more context on validation failure
+		var validationErr *jsonschema.ValidationError
+		if errors.As(err, &validationErr) {
+			log.Printf("Config file '%s' failed schema validation:", path)
+			// Pretty print the detailed validation error structure
+			if validationErr != nil {
+				util.LogDebugf("Raw schema validation error(s):\n%s", pp.Sprintln(validationErr))
+				log.Fatalf("Schema validation error: %s", validationErr.Error())
+			}
+		}
+		return errors.Wrapf(err, "config file '%s' failed schema validation", path)
+	}
+	log.Printf("Config file '%s' passed schema validation.", path)
+
+	return nil
 }
 
 func (cfg *Config) setupAWSConfig() {
@@ -63,6 +120,11 @@ func (cfg *Config) setupAWSConfig() {
 
 func (cfg *Config) setupSnowflakeConfig() (err error) {
 	// Set the type of SnowflakeConfig we are using
+	if cfg.SnowflakeConfig.NewAccountConfig != nil && cfg.SnowflakeConfig.ExistingAccountConfig != nil {
+		// This case should be caught by the schema validation, but adding a check here for safety.
+		return errors.New("SnowflakeConfig cannot contain both NewAccountConfig and ExistingAccountConfig")
+	}
+
 	if cfg.SnowflakeConfig.NewAccountConfig != nil {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeNewAccount
 
@@ -83,29 +145,50 @@ func (cfg *Config) setupSnowflakeConfig() (err error) {
 		if cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath != "" {
 			privateKey, err := os.ReadFile(cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath)
 			if err != nil {
-				return err
+				// Wrap error for better context
+				return errors.Wrapf(err,
+					"failed to read OrgAdminPrivateKey from path '%s'",
+					cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath,
+				)
 			}
 			cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKey = string(privateKey)
 		}
 	} else if cfg.SnowflakeConfig.ExistingAccountConfig != nil {
 		cfg.SnowflakeConfig.ConfigType = SnowflakeConfigTypeExistingAccount
+		// Potentially read ExistingAccountConfig private key here if needed later? (Added for completeness, no logic needed now)
+		// if cfg.SnowflakeConfig.ExistingAccountConfig.PantherAccountAdminRSAKeyPath != "" { ... }
 	} else {
-		log.Fatalf("No SnowflakeConfig or invalid SnowflakeConfig provided:\n%s", pp.Sprint(cfg.SnowflakeConfig))
+		// This case should also be caught by schema validation (oneOf).
+		log.Printf("Error: No SnowflakeConfig or invalid SnowflakeConfig provided. This should have been caught by schema validation.\n%s", pp.Sprint(cfg.SnowflakeConfig))
+		return errors.New("invalid SnowflakeConfig: must contain either NewAccountConfig or ExistingAccountConfig")
 	}
 
 	return nil
 }
 
-func (cfg *Config) validateConfig() (err error) {
-	if err := cfg.validate(); err != nil {
+func (cfg *Config) validateConfigStruct() (err error) {
+	if err := validate.Struct(cfg); err != nil {
 		var validationErrs validator.ValidationErrors
 		if errors.As(err, &validationErrs) {
-			for _, err := range validationErrs {
-				log.Printf("Config field '%s' failed validation: %s\n", err.Field(), err.ActualTag())
+			log.Println("Struct validation failed on the following fields:") // More informative log
+			for _, fe := range validationErrs {
+				// Provide more detail from the validation error
+				log.Printf("  Field: '%s', Tag: '%s', Value: '%v'\n", fe.Namespace(), fe.Tag(), fe.Value())
 			}
+		} else {
+			// Log unexpected error types from validator
+			log.Printf("An unexpected error occurred during struct validation: %v\n", err)
 		}
-		return err
+		// Return the original error for upstream handling
+		return errors.Wrapf(err, "struct field validation failed")
 	}
-
 	return nil
+}
+
+func readFileContent(filePath string) (string, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read file '%s'", filePath)
+	}
+	return string(content), nil
 }

--- a/pkg/cloudconnected/config/schema.yaml
+++ b/pkg/cloudconnected/config/schema.yaml
@@ -1,0 +1,175 @@
+type: object
+properties:
+  AWSConfig:
+    type: object
+    properties:
+      AccessKeyID:
+        type: string
+        description: Your AWS Access Key ID.
+      SecretAccessKey:
+        type: string
+        description: Your AWS Secret Access Key.
+      CloudFormationConfig:
+        type: object
+        properties:
+          DeploymentRoleName:
+            type: string
+            description: The name of the IAM role to be deployed (e.g., PantherDeploymentRole).
+          IdentityAccountId:
+            type: string
+            description: The Panther Identity AWS Account ID.
+          OpsAccountId:
+            type: string
+            description: The Panther Ops AWS Account ID.
+        required:
+          - DeploymentRoleName
+          - IdentityAccountId
+          - OpsAccountId
+      DomainCertificateConfiguration:
+        type: object
+        properties:
+          PantherSubdomain:
+            type: string
+            description: The desired subdomain for your Panther instance (e.g., panther.yourdomain.com).
+            pattern: '^([a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z]{2,}$' # Simple domain pattern
+        required:
+          - PantherSubdomain
+    required:
+      - AccessKeyID
+      - SecretAccessKey
+      - CloudFormationConfig
+      - DomainCertificateConfiguration
+  PantherAccountConfig:
+    type: object
+    properties:
+      DesiredAccountName:
+        type: string
+        description: Preferred name for the Panther account shown in the UI.
+      AdminUserFirstName:
+        type: string
+        description: First name of the initial Panther admin user.
+      AdminUserLastName:
+        type: string
+        description: Last name of the initial Panther admin user.
+      AdminEmail:
+        type: string
+        format: email
+        description: Email address of the initial Panther admin user.
+      Edition:
+        type: string
+        enum: [STANDARD, BUSINESS_CRITICAL, ENTERPRISE]
+        description: The Panther edition.
+      Region:
+        type: string
+        pattern: "^[a-z]{2}-[a-z]+-[0-9]$" # AWS region pattern e.g. us-west-2
+        description: The AWS region for the Panther deployment.
+      IpAddressAllowList:
+        type: array
+        items:
+          type: string
+          # Basic CIDR block pattern, might need refinement for stricter validation
+          pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
+        description: A list of CIDR blocks allowed to access the Panther UI.
+    required:
+      - DesiredAccountName
+      - AdminUserFirstName
+      - AdminUserLastName
+      - AdminEmail
+      - Edition
+      - Region
+      - IpAddressAllowList
+  SnowflakeConfig:
+    type: object
+    properties:
+      ExistingAccountConfig:
+        type: object
+        properties:
+          AccountName:
+            type: string
+            description: Your existing Snowflake account name.
+          URL:
+            type: string
+            format: url
+            description: The URL for your Snowflake account.
+          Edition:
+            type: string
+            enum: [STANDARD, BUSINESS_CRITICAL, ENTERPRISE]
+            description: The edition of your Snowflake account.
+          Region:
+            type: string
+            pattern: "^[a-z]{2}-[a-z]+-[0-9]$" # AWS region pattern
+            description: The AWS region where your Snowflake account is hosted.
+          PantherAccountAdminRSAKeyPath:
+            type: string
+            description: Path to the private key file for the PANTHERACCOUNTADMIN user.
+        required:
+          - AccountName
+          - URL
+          - Edition
+          - Region
+          - PantherAccountAdminRSAKeyPath
+        additionalProperties: false
+      NewAccountConfig:
+        type: object
+        properties:
+          OrgConfig:
+            type: object
+            properties:
+              AccountLocator:
+                type: string
+                description: Your Snowflake account locator.
+              AccountRegion:
+                type: string
+                pattern: "^[a-z]{2}-[a-z]+-[0-9]$" # AWS region pattern
+                description: The AWS region of your Snowflake organization account.
+              OrgAdminUsername:
+                type: string
+                description: The username for the Snowflake ORGADMIN role.
+              OrgAdminPrivateKeyPath:
+                type: string
+                description: Path to the private key file for the ORGADMIN user.
+            required:
+              - AccountLocator
+              - AccountRegion
+              - OrgAdminUsername
+              - OrgAdminPrivateKeyPath
+          SnowflakeAccountName:
+            type: string
+            description: The desired name for the new Snowflake account.
+          AdminUsername:
+            type: string
+            description: The username for the admin user of the new Snowflake account.
+          AdminPassword:
+            type: string
+            description: The password for the admin user of the new Snowflake account.
+          SnowflakeEdition:
+            type: string
+            enum: [STANDARD, BUSINESS_CRITICAL, ENTERPRISE]
+            description: The desired edition for the new Snowflake account.
+          PantherAccountAdminRSAKeyOutputPath:
+            type: string
+            description: Path where the generated PANTHERACCOUNTADMIN private key will be saved.
+        required:
+          - OrgConfig
+          - SnowflakeAccountName
+          - AdminUsername
+          - AdminPassword
+          - SnowflakeEdition
+          - PantherAccountAdminRSAKeyOutputPath
+        additionalProperties: false
+    oneOf:
+      - required: [ExistingAccountConfig]
+        properties:
+          ExistingAccountConfig: true # Makes sure this property is defined
+          NewAccountConfig: false # Makes sure this property is not defined
+      - required: [NewAccountConfig]
+        properties:
+          ExistingAccountConfig: false # Makes sure this property is not defined
+          NewAccountConfig: true # Makes sure this property is defined
+    # Prevent both keys from being present, even if one is null/empty
+    additionalProperties: false
+required:
+  - AWSConfig
+  - PantherAccountConfig
+  - SnowflakeConfig
+additionalProperties: false

--- a/pkg/cloudconnected/config/schema.yaml
+++ b/pkg/cloudconnected/config/schema.yaml
@@ -9,6 +9,9 @@ properties:
       SecretAccessKey:
         type: string
         description: Your AWS Secret Access Key.
+      SessionToken:
+        type: string
+        description: Your AWS Session Token.
       CloudFormationConfig:
         type: object
         properties:
@@ -77,7 +80,6 @@ properties:
       - AdminEmail
       - Edition
       - Region
-      - IpAddressAllowList
   SnowflakeConfig:
     type: object
     properties:

--- a/pkg/cloudconnected/snowflake/snowflake.go
+++ b/pkg/cloudconnected/snowflake/snowflake.go
@@ -20,13 +20,13 @@ func NewSnowflakeSetup(ctx context.Context, cfg *config.Config) *SnowflakeSetup 
 
 func (s *SnowflakeSetup) CreateOrResolveAccount() (resolvedAccount *ResolvedSnowflakeAcccount, err error) {
 	if s.cfg.SnowflakeConfig.ConfigType == config.SnowflakeConfigTypeNewAccount {
-		log.Println("creating new Snowflake account")
+		log.Println("Creating new Snowflake account")
 		resolvedAccount, err = s.createSnowflakeAccount()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create Snowflake account")
 		}
 	} else {
-		log.Println("existing account specified, resolving account details")
+		log.Println("Existing Snowflake account specified, resolving account details")
 
 		// fill out createAccountResult with the existing account details
 		privateKeyAsStr, err := s.cfg.SnowflakeConfig.ExistingAccountConfig.LoadPantherAccountAdminRSAKey()
@@ -57,7 +57,7 @@ func (s *SnowflakeSetup) CreateOrResolveAccount() (resolvedAccount *ResolvedSnow
 
 func (s *SnowflakeSetup) SetupAccount(resolvedAccount *ResolvedSnowflakeAcccount) error {
 	if s.cfg.SnowflakeConfig.ConfigType == config.SnowflakeConfigTypeNewAccount {
-		log.Println("setting up new Snowflake account's admin user")
+		log.Println("Setting up new Snowflake account's admin user")
 		if err := s.setupSnowflakeAdmin(resolvedAccount); err != nil {
 			return errors.Wrap(err, "failed to setup Snowflake account")
 		}

--- a/pkg/cloudconnected/snowflake/snowflake.go
+++ b/pkg/cloudconnected/snowflake/snowflake.go
@@ -18,19 +18,16 @@ func NewSnowflakeSetup(ctx context.Context, cfg *config.Config) *SnowflakeSetup 
 	return &SnowflakeSetup{ctx, cfg}
 }
 
-func (s *SnowflakeSetup) Run() (resolvedAccount *ResolvedSnowflakeAcccount, err error) {
+func (s *SnowflakeSetup) CreateOrResolveAccount() (resolvedAccount *ResolvedSnowflakeAcccount, err error) {
 	if s.cfg.SnowflakeConfig.ConfigType == config.SnowflakeConfigTypeNewAccount {
-		// create the account
+		log.Println("creating new Snowflake account")
 		resolvedAccount, err = s.createSnowflakeAccount()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create Snowflake account")
 		}
-
-		// setup the account
-		if err := s.setupSnowflakeAdmin(resolvedAccount); err != nil {
-			return nil, errors.Wrap(err, "failed to setup Snowflake account")
-		}
 	} else {
+		log.Println("existing account specified, resolving account details")
+
 		// fill out createAccountResult with the existing account details
 		privateKeyAsStr, err := s.cfg.SnowflakeConfig.ExistingAccountConfig.LoadPantherAccountAdminRSAKey()
 		if err != nil {
@@ -56,6 +53,17 @@ func (s *SnowflakeSetup) Run() (resolvedAccount *ResolvedSnowflakeAcccount, err 
 	}
 
 	return resolvedAccount, nil
+}
+
+func (s *SnowflakeSetup) SetupAccount(resolvedAccount *ResolvedSnowflakeAcccount) error {
+	if s.cfg.SnowflakeConfig.ConfigType == config.SnowflakeConfigTypeNewAccount {
+		log.Println("setting up new Snowflake account's admin user")
+		if err := s.setupSnowflakeAdmin(resolvedAccount); err != nil {
+			return errors.Wrap(err, "failed to setup Snowflake account")
+		}
+	}
+
+	return nil
 }
 
 // Uses orgadmin (provided with RSA key) to create a new account whose first admin user is

--- a/pkg/state/db.go
+++ b/pkg/state/db.go
@@ -18,6 +18,7 @@ const (
 		snowflake_account_url TEXT,
 		snowflake_edition TEXT,
 		snowflake_region TEXT,
+		snowflake_account_setup BOOLEAN,
 		aws_panther_deployment_role_deployed BOOLEAN,
 		aws_readiness_bootstrap_tools_deployed BOOLEAN,
 		aws_readiness_check_succeeded BOOLEAN,
@@ -78,6 +79,7 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 			snowflake_account_url,
 			snowflake_edition,
 			snowflake_region,
+			snowflake_account_setup,
 			aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded,
@@ -96,6 +98,7 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 		&row.SnowflakeAccountURL,
 		&row.SnowflakeEdition,
 		&row.SnowflakeRegion,
+		&row.SnowflakeAccountSetup,
 		&row.AWSPantherDeploymentRoleDeployed,
 		&row.AWSReadinessBootstrapToolsDeployed,
 		&row.AWSReadinessCheckSucceeded,
@@ -162,6 +165,7 @@ func (d *DB) SaveState(row *Row) error {
 			snowflake_account_url,
 			snowflake_edition,
 			snowflake_region,
+			snowflake_account_setup,
 			aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded,
@@ -170,11 +174,12 @@ func (d *DB) SaveState(row *Row) error {
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
 			aws_certificates_results
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(config_hash) DO UPDATE SET
 			snowflake_account_name = excluded.snowflake_account_name,
 			snowflake_account_url = excluded.snowflake_account_url,
 			snowflake_edition = excluded.snowflake_edition,
+			snowflake_account_setup = excluded.snowflake_account_setup,
 			aws_panther_deployment_role_deployed = excluded.aws_panther_deployment_role_deployed,
 			aws_readiness_bootstrap_tools_deployed = excluded.aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded = excluded.aws_readiness_check_succeeded,
@@ -191,6 +196,7 @@ func (d *DB) SaveState(row *Row) error {
 		row.SnowflakeAccountURL,
 		row.SnowflakeEdition,
 		row.SnowflakeRegion,
+		row.SnowflakeAccountSetup,
 		row.AWSPantherDeploymentRoleDeployed,
 		row.AWSReadinessBootstrapToolsDeployed,
 		row.AWSReadinessCheckSucceeded,

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -69,8 +69,9 @@ func (m *Manager) GetState() *Row {
 }
 
 // UpdateSnowflakeState updates the Snowflake-related state
-func (m *Manager) UpdateSnowflakeState(accountDetails *snowflake.ResolvedSnowflakeAcccount) error {
+func (m *Manager) UpdateSnowflakeState(accountDetails *snowflake.ResolvedSnowflakeAcccount, accountSetup bool) error {
 	m.state.PopulateSnowflakeAccountDetails(accountDetails)
+	m.state.SnowflakeAccountSetup = accountSetup
 	return m.SaveState()
 }
 

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -371,7 +371,7 @@ func TestSnowflakeState(t *testing.T) {
 		}
 
 		// Update Snowflake state
-		err = manager.UpdateSnowflakeState(accountDetails)
+		err = manager.UpdateSnowflakeState(accountDetails, true)
 		require.NoError(t, err)
 
 		// Verify state

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -79,6 +79,7 @@ type Row struct {
 	SnowflakeAccountURL                string
 	SnowflakeEdition                   string
 	SnowflakeRegion                    string
+	SnowflakeAccountSetup              bool
 	AWSPantherDeploymentRoleDeployed   bool
 	AWSReadinessBootstrapToolsDeployed bool
 	AWSReadinessCheckSucceeded         bool
@@ -106,6 +107,7 @@ type OutputDetails struct {
 	SnowflakeAccountURL  string `json:"snowflake_account_url,omitempty"`
 	SnowflakeEdition     string `json:"snowflake_edition,omitempty"`
 	SnowflakeRegion      string `json:"snowflake_region,omitempty"`
+	SnowflakeAdminSetup  bool   `json:"snowflake_admin_setup,omitempty"`
 	AWSAccountID         string `json:"aws_account_id"`
 
 	PantherCertificateARN  string                 `json:"panther_certificate_arn,omitempty"`


### PR DESCRIPTION
## Overview

Using the `validator` package is good but not very declarative for end users. This change adds a YAML schema and applies schema validation before trying to build out the `config.Config` struct.

<!-- What did you add? -->
- added YAML schema
- implement schema validation as part of config load

- broke snowflake account create and setup into distinct calls so we can track the state of these operations independently for a better user retry experience


<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [x] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: https://panther-labs.atlassian.net/browse/EPD-2992