### PR TITLE
feat: Add deployment role updater stack

### DIFF
--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -145,16 +145,16 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
 	currentState := stateManager.GetState()
 
-	needsSetup := !currentState.AWSPantherDeploymentRoleDeployed || 
+	needsSetup := !currentState.AWSPantherDeploymentRoleDeployed ||
 		!currentState.AWSReadinessBootstrapToolsDeployed ||
 		!currentState.AWSDeploymentRoleUpdaterDeployed
-	
+
 	if needsSetup {
 		awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to initialize AWS CloudFormation")
 		}
-	
+
 		if !currentState.AWSPantherDeploymentRoleDeployed {
 			log.Println("Deploying PantherDeploymentRole...")
 			if err := awsSetup.ApplyDeploymentRole(); err != nil {
@@ -168,7 +168,7 @@ func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manag
 			if err := stateManager.UpdateAWSDeploymentState(true); err != nil {
 				return errors.Wrap(err, "failed to update AWS deployment state")
 			}
-			
+
 			log.Println("Successfully deployed PantherDeploymentRole")
 		} else {
 			log.Println("Using existing PantherDeploymentRole")
@@ -187,7 +187,7 @@ func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manag
 			if err := stateManager.UpdateAWSBootstrapState(true); err != nil {
 				return errors.Wrap(err, "failed to update AWS bootstrap state")
 			}
-			
+
 			log.Println("Successfully deployed pre-deployment tools")
 		} else {
 			log.Println("Using existing pre-deployment tools")
@@ -207,7 +207,7 @@ func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manag
 			if err := stateManager.UpdateAWSDeploymentRoleUpdaterState(true); err != nil {
 				return errors.Wrap(err, "failed to update AWS deployment role updater state")
 			}
-			
+
 			log.Println("Successfully deployed deployment role updater")
 		} else {
 			log.Println("Using existing deployment role updater")

--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -145,34 +145,72 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
 	currentState := stateManager.GetState()
 
-	if !currentState.AWSPantherDeploymentRoleDeployed || !currentState.AWSReadinessBootstrapToolsDeployed {
-		awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
-		if err != nil {
-			return errors.Wrap(err, "failed to initialize AWS CloudFormation")
+	awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize AWS CloudFormation")
+	}
+
+	needsSetup := !currentState.AWSPantherDeploymentRoleDeployed || 
+		!currentState.AWSReadinessBootstrapToolsDeployed ||
+		!currentState.AWSDeploymentRoleUpdaterDeployed
+	
+	if needsSetup {
+		if !currentState.AWSPantherDeploymentRoleDeployed {
+			log.Println("Deploying PantherDeploymentRole...")
+			if err := awsSetup.ApplyDeploymentRole(); err != nil {
+				return errors.Wrapf(
+					err,
+					"failed to create deployment role stack (%s)",
+					cfg.AWSConfig.CloudFormationConfig.DeploymentRoleName,
+				)
+			}
+
+			if err := stateManager.UpdateAWSDeploymentState(true); err != nil {
+				return errors.Wrap(err, "failed to update AWS deployment state")
+			}
+			
+			log.Println("Successfully deployed PantherDeploymentRole")
+		} else {
+			log.Println("Using existing PantherDeploymentRole")
 		}
 
-		if err := awsSetup.ApplyDeploymentRole(); err != nil {
-			return errors.Wrapf(
-				err,
-				"failed to create deployment role stack (%s)",
-				cfg.AWSConfig.CloudFormationConfig.DeploymentRoleName,
-			)
+		if !currentState.AWSReadinessBootstrapToolsDeployed {
+			log.Println("Deploying pre-deployment tools...")
+			if err := awsSetup.ApplyPreDeploymentTools(); err != nil {
+				return errors.Wrapf(
+					err,
+					"failed to apply pre-deployment tools stack (%s)",
+					cfg.AWSConfig.CloudFormationConfig.PreDeploymentToolsStackName,
+				)
+			}
+
+			if err := stateManager.UpdateAWSBootstrapState(true); err != nil {
+				return errors.Wrap(err, "failed to update AWS bootstrap state")
+			}
+			
+			log.Println("Successfully deployed pre-deployment tools")
+		} else {
+			log.Println("Using existing pre-deployment tools")
 		}
 
-		if err := stateManager.UpdateAWSDeploymentState(true); err != nil {
-			return errors.Wrap(err, "failed to update AWS deployment state")
-		}
+		// Deploy Deployment Role Updater if needed
+		if !currentState.AWSDeploymentRoleUpdaterDeployed {
+			log.Println("Deploying deployment role updater...")
+			if err := awsSetup.ApplyDeploymentRoleUpdater(); err != nil {
+				return errors.Wrapf(
+					err,
+					"failed to apply deployment role updater stack (%s)",
+					cfg.AWSConfig.CloudFormationConfig.DeploymentRoleUpdaterStackName,
+				)
+			}
 
-		if err := awsSetup.ApplyPreDeploymentTools(); err != nil {
-			return errors.Wrapf(
-				err,
-				"failed to apply pre-deployment tools stack (%s)",
-				cfg.AWSConfig.CloudFormationConfig.PreDeploymentToolsStackName,
-			)
-		}
-
-		if err := stateManager.UpdateAWSBootstrapState(true); err != nil {
-			return errors.Wrap(err, "failed to update AWS bootstrap state")
+			if err := stateManager.UpdateAWSDeploymentRoleUpdaterState(true); err != nil {
+				return errors.Wrap(err, "failed to update AWS deployment role updater state")
+			}
+			
+			log.Println("Successfully deployed deployment role updater")
+		} else {
+			log.Println("Using existing deployment role updater")
 		}
 	} else {
 		log.Println("Using existing AWS setup")

--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -145,16 +145,16 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
 	currentState := stateManager.GetState()
 
-	awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
-	if err != nil {
-		return errors.Wrap(err, "failed to initialize AWS CloudFormation")
-	}
-
 	needsSetup := !currentState.AWSPantherDeploymentRoleDeployed || 
 		!currentState.AWSReadinessBootstrapToolsDeployed ||
 		!currentState.AWSDeploymentRoleUpdaterDeployed
 	
 	if needsSetup {
+		awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
+		if err != nil {
+			return errors.Wrap(err, "failed to initialize AWS CloudFormation")
+		}
+	
 		if !currentState.AWSPantherDeploymentRoleDeployed {
 			log.Println("Deploying PantherDeploymentRole...")
 			if err := awsSetup.ApplyDeploymentRole(); err != nil {

--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -145,11 +145,7 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
 	currentState := stateManager.GetState()
 
-	needsSetup := !currentState.AWSPantherDeploymentRoleDeployed ||
-		!currentState.AWSReadinessBootstrapToolsDeployed ||
-		!currentState.AWSDeploymentRoleUpdaterDeployed
-
-	if needsSetup {
+	if !currentState.IsAWSSetup() {
 		awsSetup, err := aws.NewCloudFormation(ctx, cfg.AWSConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to initialize AWS CloudFormation")
@@ -194,7 +190,7 @@ func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manag
 		}
 
 		// Deploy Deployment Role Updater if needed
-		if !currentState.AWSDeploymentRoleUpdaterDeployed {
+		if !currentState.AWSPantherDeploymentRoleUpdaterDeployed {
 			log.Println("Deploying deployment role updater...")
 			if err := awsSetup.ApplyDeploymentRoleUpdater(); err != nil {
 				return errors.Wrapf(

--- a/pkg/cloudconnected/aws/cloud_formation.go
+++ b/pkg/cloudconnected/aws/cloud_formation.go
@@ -88,6 +88,34 @@ func (c *CloudFormation) ApplyPreDeploymentTools() error {
 	)
 }
 
+func (c *CloudFormation) ApplyDeploymentRoleUpdater() error {
+	templateContent, err := util.LoadContent(c.ctx, c.cfg.CloudFormationConfig.DeploymentRoleUpdaterTemplateURL)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch CloudFormation template for deployment role updater")
+	}
+
+	log.Printf("Deploying deployment role updater from '%s'", c.cfg.CloudFormationConfig.DeploymentRoleUpdaterTemplateURL)
+
+	stackName := c.cfg.CloudFormationConfig.DeploymentRoleUpdaterStackName
+
+	parameters := []types.Parameter{
+		{
+			ParameterKey:   aws.String("DeploymentRoleStackName"),
+			ParameterValue: aws.String(c.cfg.CloudFormationConfig.DeploymentRoleStackName),
+		},
+		{
+			ParameterKey:   aws.String("IdentityAccountId"),
+			ParameterValue: aws.String(c.cfg.CloudFormationConfig.IdentityAccountId),
+		},
+		{
+			ParameterKey:   aws.String("OpsAccountId"),
+			ParameterValue: aws.String(c.cfg.CloudFormationConfig.OpsAccountId),
+		},
+	}
+
+	return c.applyCloudFormationTemplate(templateContent, stackName, parameters)
+}
+
 func (c *CloudFormation) applyCloudFormationTemplate(
 	templateContent string,
 	stackName string,

--- a/pkg/cloudconnected/config/aws.go
+++ b/pkg/cloudconnected/config/aws.go
@@ -55,13 +55,15 @@ func (a *AWSConfig) MustGetAWSAccountID() string {
 
 //nolint:lll
 type CloudFormationConfig struct {
-	IdentityAccountId             string `yaml:"IdentityAccountId"             validate:"required"`
-	OpsAccountId                  string `yaml:"OpsAccountId"                  validate:"required"`
-	DeploymentRoleName            string `yaml:"DeploymentRoleName"                                default:"PantherDeploymentRole"`
-	DeploymentRoleTemplateURL     string `yaml:"DeploymentRoleTemplateURL"                         default:"https://panther-public-cloudformation-templates.s3.us-west-2.amazonaws.com/panther-deployment-role/latest/template.yml"`
-	DeploymentRoleStackName       string `yaml:"DeploymentRoleStackName"                           default:"PantherDeploymentRoleStack"`
-	PreDeploymentToolsTemplateURL string `yaml:"PreDeploymentToolsTemplateURL"                     default:"https://panther-public-cloudformation-templates.s3.us-west-2.amazonaws.com/panther-preflight-tools-%s/latest/template.yml"`
-	PreDeploymentToolsStackName   string `yaml:"PreDeploymentToolsStackName"                       default:"PantherPreDeploymentTools"`
+	IdentityAccountId                string `yaml:"IdentityAccountId"             validate:"required"`
+	OpsAccountId                     string `yaml:"OpsAccountId"                  validate:"required"`
+	DeploymentRoleName               string `yaml:"DeploymentRoleName"                                default:"PantherDeploymentRole"`
+	DeploymentRoleTemplateURL        string `yaml:"DeploymentRoleTemplateURL"                         default:"https://panther-public-cloudformation-templates.s3.us-west-2.amazonaws.com/panther-deployment-role/latest/template.yml"`
+	DeploymentRoleStackName          string `yaml:"DeploymentRoleStackName"                           default:"PantherDeploymentRoleStack"`
+	PreDeploymentToolsTemplateURL    string `yaml:"PreDeploymentToolsTemplateURL"                     default:"https://panther-public-cloudformation-templates.s3.us-west-2.amazonaws.com/panther-preflight-tools-%s/latest/template.yml"`
+	PreDeploymentToolsStackName      string `yaml:"PreDeploymentToolsStackName"                       default:"PantherPreDeploymentTools"`
+	DeploymentRoleUpdaterTemplateURL string `yaml:"DeploymentRoleUpdaterTemplateURL"                  default:"https://panther-public-cloudformation-templates.s3.us-west-2.amazonaws.com/panther-deployment-updater-role/latest/template.yml"`
+	DeploymentRoleUpdaterStackName   string `yaml:"DeploymentRoleUpdaterStackName"                    default:"PantherDeploymentUpdaterRoleStack"`
 }
 
 type DomainCertificateConfiguration struct {

--- a/pkg/state/db.go
+++ b/pkg/state/db.go
@@ -27,7 +27,8 @@ const (
 		aws_snowflake_bootstrap_succeeded BOOLEAN,
 		aws_snowflake_secret_arn TEXT,
 		aws_certificates_requested BOOLEAN,
-		aws_certificates_results JSON
+		aws_certificates_results JSON,
+		aws_deployment_role_updater_deployed BOOLEAN
 	)`
 )
 
@@ -89,7 +90,8 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 			aws_snowflake_bootstrap_succeeded,
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
-			aws_certificates_results
+			aws_certificates_results,
+			aws_deployment_role_updater_deployed
 		FROM execution_state
 		WHERE config_hash = ?`
 
@@ -110,6 +112,7 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 		&row.AWSSnowflakeSecretARN,
 		&row.AWSCertificatesRequested,
 		&row.AWSCertificatesResults,
+		&row.AWSDeploymentRoleUpdaterDeployed,
 	)
 
 	if err == sql.ErrNoRows {
@@ -177,8 +180,9 @@ func (d *DB) SaveState(row *Row) error {
 			aws_snowflake_bootstrap_succeeded,
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
-			aws_certificates_results
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			aws_certificates_results,
+			aws_deployment_role_updater_deployed
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(config_hash) DO UPDATE SET
 			snowflake_account_name = excluded.snowflake_account_name,
 			snowflake_account_url = excluded.snowflake_account_url,
@@ -192,7 +196,8 @@ func (d *DB) SaveState(row *Row) error {
 			aws_snowflake_bootstrap_succeeded = excluded.aws_snowflake_bootstrap_succeeded,
 			aws_snowflake_secret_arn = excluded.aws_snowflake_secret_arn,
 			aws_certificates_requested = excluded.aws_certificates_requested,
-			aws_certificates_results = excluded.aws_certificates_results`
+			aws_certificates_results = excluded.aws_certificates_results,
+			aws_deployment_role_updater_deployed = excluded.aws_deployment_role_updater_deployed`
 
 	_, err := d.db.Exec(
 		query,
@@ -211,6 +216,7 @@ func (d *DB) SaveState(row *Row) error {
 		row.AWSSnowflakeSecretARN,
 		row.AWSCertificatesRequested,
 		row.AWSCertificatesResults,
+		row.AWSDeploymentRoleUpdaterDeployed,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to save state")

--- a/pkg/state/db.go
+++ b/pkg/state/db.go
@@ -21,14 +21,14 @@ const (
 		snowflake_account_setup BOOLEAN,
 		snowflake_admin_username TEXT,
 		aws_panther_deployment_role_deployed BOOLEAN,
+		aws_panther_deployment_role_updater_deployed BOOLEAN,
 		aws_readiness_bootstrap_tools_deployed BOOLEAN,
 		aws_readiness_check_succeeded BOOLEAN,
 		aws_readiness_check_results JSON,
 		aws_snowflake_bootstrap_succeeded BOOLEAN,
 		aws_snowflake_secret_arn TEXT,
 		aws_certificates_requested BOOLEAN,
-		aws_certificates_results JSON,
-		aws_deployment_role_updater_deployed BOOLEAN
+		aws_certificates_results JSON
 	)`
 )
 
@@ -84,14 +84,14 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 			snowflake_account_setup,
 			snowflake_admin_username,
 			aws_panther_deployment_role_deployed,
+			aws_panther_deployment_role_updater_deployed,
 			aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded,
 			aws_readiness_check_results,
 			aws_snowflake_bootstrap_succeeded,
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
-			aws_certificates_results,
-			aws_deployment_role_updater_deployed
+			aws_certificates_results
 		FROM execution_state
 		WHERE config_hash = ?`
 
@@ -105,6 +105,7 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 		&row.SnowflakeAccountSetup,
 		&row.SnowflakeAdminUsername,
 		&row.AWSPantherDeploymentRoleDeployed,
+		&row.AWSPantherDeploymentRoleUpdaterDeployed,
 		&row.AWSReadinessBootstrapToolsDeployed,
 		&row.AWSReadinessCheckSucceeded,
 		&row.AWSReadinessCheckResults,
@@ -112,7 +113,6 @@ func (d *DB) GetState(configHash string) (*Row, error) {
 		&row.AWSSnowflakeSecretARN,
 		&row.AWSCertificatesRequested,
 		&row.AWSCertificatesResults,
-		&row.AWSDeploymentRoleUpdaterDeployed,
 	)
 
 	if err == sql.ErrNoRows {
@@ -174,14 +174,14 @@ func (d *DB) SaveState(row *Row) error {
 			snowflake_account_setup,
 			snowflake_admin_username,
 			aws_panther_deployment_role_deployed,
+			aws_panther_deployment_role_updater_deployed,
 			aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded,
 			aws_readiness_check_results,
 			aws_snowflake_bootstrap_succeeded,
 			aws_snowflake_secret_arn,
 			aws_certificates_requested,
-			aws_certificates_results,
-			aws_deployment_role_updater_deployed
+			aws_certificates_results
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(config_hash) DO UPDATE SET
 			snowflake_account_name = excluded.snowflake_account_name,
@@ -190,14 +190,14 @@ func (d *DB) SaveState(row *Row) error {
 			snowflake_account_setup = excluded.snowflake_account_setup,
 			snowflake_admin_username = excluded.snowflake_admin_username,
 			aws_panther_deployment_role_deployed = excluded.aws_panther_deployment_role_deployed,
+			aws_panther_deployment_role_updater_deployed = excluded.aws_panther_deployment_role_updater_deployed,
 			aws_readiness_bootstrap_tools_deployed = excluded.aws_readiness_bootstrap_tools_deployed,
 			aws_readiness_check_succeeded = excluded.aws_readiness_check_succeeded,
 			aws_readiness_check_results = excluded.aws_readiness_check_results,
 			aws_snowflake_bootstrap_succeeded = excluded.aws_snowflake_bootstrap_succeeded,
 			aws_snowflake_secret_arn = excluded.aws_snowflake_secret_arn,
 			aws_certificates_requested = excluded.aws_certificates_requested,
-			aws_certificates_results = excluded.aws_certificates_results,
-			aws_deployment_role_updater_deployed = excluded.aws_deployment_role_updater_deployed`
+			aws_certificates_results = excluded.aws_certificates_results`
 
 	_, err := d.db.Exec(
 		query,
@@ -209,6 +209,7 @@ func (d *DB) SaveState(row *Row) error {
 		row.SnowflakeAccountSetup,
 		row.SnowflakeAdminUsername,
 		row.AWSPantherDeploymentRoleDeployed,
+		row.AWSPantherDeploymentRoleUpdaterDeployed,
 		row.AWSReadinessBootstrapToolsDeployed,
 		row.AWSReadinessCheckSucceeded,
 		row.AWSReadinessCheckResults,
@@ -216,7 +217,6 @@ func (d *DB) SaveState(row *Row) error {
 		row.AWSSnowflakeSecretARN,
 		row.AWSCertificatesRequested,
 		row.AWSCertificatesResults,
-		row.AWSDeploymentRoleUpdaterDeployed,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to save state")

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -101,9 +101,9 @@ func (m *Manager) UpdateAWSSnowflakeBootstrapState(succeeded bool, secretARN str
 	return m.SaveState()
 }
 
-// UpdateAWSDeploymentRoleUpdaterState updates the AWS deployment role updater deployment state
+// UpdateAWSDeploymentRoleUpdaterState updates the AWS Panther deployment role updater deployment state
 func (m *Manager) UpdateAWSDeploymentRoleUpdaterState(deployed bool) error {
-	m.state.AWSDeploymentRoleUpdaterDeployed = deployed
+	m.state.AWSPantherDeploymentRoleUpdaterDeployed = deployed
 	return m.SaveState()
 }
 

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -101,6 +101,12 @@ func (m *Manager) UpdateAWSSnowflakeBootstrapState(succeeded bool, secretARN str
 	return m.SaveState()
 }
 
+// UpdateAWSDeploymentRoleUpdaterState updates the AWS deployment role updater deployment state
+func (m *Manager) UpdateAWSDeploymentRoleUpdaterState(deployed bool) error {
+	m.state.AWSDeploymentRoleUpdaterDeployed = deployed
+	return m.SaveState()
+}
+
 // UpdateCertificateState updates the certificate state with new results
 func (m *Manager) UpdateCertificateState(
 	certType string,

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -89,6 +89,7 @@ type Row struct {
 	AWSSnowflakeSecretARN              string
 	AWSCertificatesRequested           bool
 	AWSCertificatesResults             CertificateResults
+	AWSDeploymentRoleUpdaterDeployed   bool
 }
 
 // OutputDetails contains the structured information for formatted output
@@ -246,6 +247,7 @@ func (r *Row) createStructuredOutput(cfg *config.Config) OutputDetails {
 	output.DeploymentStatus["aws_bootstrap_tools_deployed"] = r.AWSReadinessBootstrapToolsDeployed
 	output.DeploymentStatus["aws_readiness_check_succeeded"] = r.AWSReadinessCheckSucceeded
 	output.DeploymentStatus["aws_snowflake_bootstrap_succeeded"] = r.AWSSnowflakeBootstrapSucceeded
+	output.DeploymentStatus["aws_deployment_role_updater_deployed"] = r.AWSDeploymentRoleUpdaterDeployed
 
 	// Use the ARN from state if available
 	if r.AWSSnowflakeBootstrapSucceeded && r.AWSSnowflakeSecretARN != "" {

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -81,15 +81,17 @@ type Row struct {
 	SnowflakeRegion                    string
 	SnowflakeAccountSetup              bool
 	SnowflakeAdminUsername             string
-	AWSPantherDeploymentRoleDeployed   bool
-	AWSReadinessBootstrapToolsDeployed bool
-	AWSReadinessCheckSucceeded         bool
-	AWSReadinessCheckResults           ReadinessCheckResults
-	AWSSnowflakeBootstrapSucceeded     bool
-	AWSSnowflakeSecretARN              string
-	AWSCertificatesRequested           bool
-	AWSCertificatesResults             CertificateResults
-	AWSDeploymentRoleUpdaterDeployed   bool
+	
+	AWSPantherDeploymentRoleDeployed          bool
+	AWSPantherDeploymentRoleUpdaterDeployed   bool
+	AWSReadinessBootstrapToolsDeployed        bool
+	AWSReadinessCheckSucceeded                bool
+	AWSReadinessCheckResults                  ReadinessCheckResults
+	AWSSnowflakeBootstrapSucceeded            bool
+	AWSSnowflakeSecretARN                     string
+	AWSCertificatesRequested                  bool
+	AWSCertificatesResults                    CertificateResults
+	
 }
 
 // OutputDetails contains the structured information for formatted output
@@ -219,6 +221,12 @@ func (r *Row) FormatJSON(cfg *config.Config) (string, error) {
 	return string(jsonData), nil
 }
 
+func (r *Row) IsAWSSetup() bool {
+	return r.AWSPantherDeploymentRoleDeployed &&
+		r.AWSReadinessBootstrapToolsDeployed &&
+		r.AWSPantherDeploymentRoleUpdaterDeployed
+}
+
 // createStructuredOutput creates a structured output object with relevant information
 func (r *Row) createStructuredOutput(cfg *config.Config) OutputDetails {
 	// Initialize the output structure
@@ -244,10 +252,10 @@ func (r *Row) createStructuredOutput(cfg *config.Config) OutputDetails {
 
 	// Add deployment status information
 	output.DeploymentStatus["aws_deployment_role_deployed"] = r.AWSPantherDeploymentRoleDeployed
+	output.DeploymentStatus["aws_deployment_role_updater_deployed"] = r.AWSPantherDeploymentRoleUpdaterDeployed
 	output.DeploymentStatus["aws_bootstrap_tools_deployed"] = r.AWSReadinessBootstrapToolsDeployed
 	output.DeploymentStatus["aws_readiness_check_succeeded"] = r.AWSReadinessCheckSucceeded
-	output.DeploymentStatus["aws_snowflake_bootstrap_succeeded"] = r.AWSSnowflakeBootstrapSucceeded
-	output.DeploymentStatus["aws_deployment_role_updater_deployed"] = r.AWSDeploymentRoleUpdaterDeployed
+	output.DeploymentStatus["aws_snowflake_bootstrap_succeeded"] = r.AWSSnowflakeBootstrapSucceeded	
 
 	// Use the ARN from state if available
 	if r.AWSSnowflakeBootstrapSucceeded && r.AWSSnowflakeSecretARN != "" {

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -74,24 +74,23 @@ func (r *ReadinessCheckResults) Scan(value interface{}) error {
 }
 
 type Row struct {
-	ConfigHash                         string `validate:"sha256"`
-	SnowflakeAccountName               string
-	SnowflakeAccountURL                string
-	SnowflakeEdition                   string
-	SnowflakeRegion                    string
-	SnowflakeAccountSetup              bool
-	SnowflakeAdminUsername             string
-	
-	AWSPantherDeploymentRoleDeployed          bool
-	AWSPantherDeploymentRoleUpdaterDeployed   bool
-	AWSReadinessBootstrapToolsDeployed        bool
-	AWSReadinessCheckSucceeded                bool
-	AWSReadinessCheckResults                  ReadinessCheckResults
-	AWSSnowflakeBootstrapSucceeded            bool
-	AWSSnowflakeSecretARN                     string
-	AWSCertificatesRequested                  bool
-	AWSCertificatesResults                    CertificateResults
-	
+	ConfigHash             string `validate:"sha256"`
+	SnowflakeAccountName   string
+	SnowflakeAccountURL    string
+	SnowflakeEdition       string
+	SnowflakeRegion        string
+	SnowflakeAccountSetup  bool
+	SnowflakeAdminUsername string
+
+	AWSPantherDeploymentRoleDeployed        bool
+	AWSPantherDeploymentRoleUpdaterDeployed bool
+	AWSReadinessBootstrapToolsDeployed      bool
+	AWSReadinessCheckSucceeded              bool
+	AWSReadinessCheckResults                ReadinessCheckResults
+	AWSSnowflakeBootstrapSucceeded          bool
+	AWSSnowflakeSecretARN                   string
+	AWSCertificatesRequested                bool
+	AWSCertificatesResults                  CertificateResults
 }
 
 // OutputDetails contains the structured information for formatted output
@@ -255,7 +254,7 @@ func (r *Row) createStructuredOutput(cfg *config.Config) OutputDetails {
 	output.DeploymentStatus["aws_deployment_role_updater_deployed"] = r.AWSPantherDeploymentRoleUpdaterDeployed
 	output.DeploymentStatus["aws_bootstrap_tools_deployed"] = r.AWSReadinessBootstrapToolsDeployed
 	output.DeploymentStatus["aws_readiness_check_succeeded"] = r.AWSReadinessCheckSucceeded
-	output.DeploymentStatus["aws_snowflake_bootstrap_succeeded"] = r.AWSSnowflakeBootstrapSucceeded	
+	output.DeploymentStatus["aws_snowflake_bootstrap_succeeded"] = r.AWSSnowflakeBootstrapSucceeded
 
 	// Use the ARN from state if available
 	if r.AWSSnowflakeBootstrapSucceeded && r.AWSSnowflakeSecretARN != "" {


### PR DESCRIPTION
## Overview

- added
  - Adds a CFN deployment of the deployment role updater stack next to the existing CFN deploys


<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [x] This change has been tested against a real environment
  - I tested this with a partial run against my dev account with a different region. The updater stack had the correct parameters.
## Breadcrumbs (for Panther Labs Engineers)

- jira: EPD-2959