### PR TITLE
Wrong validation used for IpAddressAllowList.

### DIFF
--- a/pkg/cloudconnected/config/panther.go
+++ b/pkg/cloudconnected/config/panther.go
@@ -8,5 +8,5 @@ type PantherAccountConfig struct {
 	DesiredAccountName string   `yaml:"DesiredAccountName" validate:"required"`
 	Edition            string   `yaml:"Edition"            validate:"required,oneof=ENTERPRISE ESSENTIALS"` // if PantherEdition==Enterprise, SnowflakeEdition must be Enterprise
 	Region             string   `yaml:"Region"             validate:"required,validPantherRegion"`          // this informs which Snowflake region we use, currently AWS-only
-	IpAddressAllowList []string `yaml:"IpAddressAllowList" validate:"omitempty,dive,ip"`                    // Optional list of allowed IP addresses
+	IpAddressAllowList []string `yaml:"IpAddressAllowList" validate:"omitempty,dive,cidr"`                  // Optional list of allowed IP addresses
 }


### PR DESCRIPTION
<!--
This repo is made possible by contributors like you. Thank you.
Please include a high level overview of the changes made
-->

## Overview

Side commentary: The property referenced here is probably incorrectly named, but I'm not really sure I care to change it. I may add a back-compat new field that'll use either so that folks w/ automation built around the field can use either and we just mark `IpAddressAllowList` as a deprecated field.

That's a change for another day though.

<!-- What did you change? -->
- changed the validation type from `ip` to `cidr` for `IpAddressAllowList`

<!-- What did you remove? -->
- removed...

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [x] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- slack context: https://panther-labs.slack.com/archives/C08ACUH7621/p1750953363695559?thread_ts=1750801076.122299&cid=C08ACUH7621