### PR TITLE
Register the wildcard in the target region, not just us-east-1

### DIFF
--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -30,14 +30,21 @@ func setupCertificates(ctx context.Context, cfg *config.Config, stateManager *st
 			return errors.Wrap(err, "failed to update panther certificate state")
 		}
 
-		// Register wildcard certificate
-		wildcardResult, err := certHelper.RegisterWildcardSubdomainCertificate()
-		if err != nil {
-			return errors.Wrap(err, "failed to register wildcard certificate")
-		}
-		log.Printf("Registered wildcard certificate:\n%s\n", pp.Sprintln(wildcardResult))
-		if err := stateManager.UpdateCertificateState("wildcard", wildcardResult, false); err != nil {
-			return errors.Wrap(err, "failed to update wildcard certificate state")
+		if cfg.AWSConfig.Region != "us-east-1" {
+			// Register wildcard certificate
+			wildcardResult, err := certHelper.RegisterWildcardSubdomainCertificate()
+			if err != nil {
+				return errors.Wrap(err, "failed to register wildcard certificate")
+			}
+			log.Printf("Registered wildcard certificate:\n%s\n", pp.Sprintln(wildcardResult))
+			if err := stateManager.UpdateCertificateState("wildcard", wildcardResult, false); err != nil {
+				return errors.Wrap(err, "failed to update wildcard certificate state")
+			}
+		} else {
+			log.Printf("Using panther certificate as wildcard certificate in us-east-1 region\n")
+			if err := stateManager.UpdateCertificateState("wildcard", pantherResult, false); err != nil {
+				return errors.Wrap(err, "failed to update wildcard certificate state")
+			}
 		}
 
 		// Print DNS validation instructions
@@ -68,7 +75,7 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 				aws.CertificateRegistrationResult{
 					CertificateArn: certs.PantherSubdomain.CertificateArn,
 					ValidationDetails: aws.CertificateValidationDetails{
-						DomainName:  certs.PantherSubdomain.ValidationDetails.DomainName,
+						DomainNames: certs.PantherSubdomain.ValidationDetails.DomainNames,
 						RecordName:  certs.PantherSubdomain.ValidationDetails.RecordName,
 						RecordValue: certs.PantherSubdomain.ValidationDetails.RecordValue,
 						RecordType:  certs.PantherSubdomain.ValidationDetails.RecordType,
@@ -94,7 +101,7 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 				aws.CertificateRegistrationResult{
 					CertificateArn: certs.WildcardSubdomain.CertificateArn,
 					ValidationDetails: aws.CertificateValidationDetails{
-						DomainName:  certs.WildcardSubdomain.ValidationDetails.DomainName,
+						DomainNames: certs.WildcardSubdomain.ValidationDetails.DomainNames,
 						RecordName:  certs.WildcardSubdomain.ValidationDetails.RecordName,
 						RecordValue: certs.WildcardSubdomain.ValidationDetails.RecordValue,
 						RecordType:  certs.WildcardSubdomain.ValidationDetails.RecordType,
@@ -122,9 +129,13 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 
 func printDNSValidationInstructions(certs state.CertificateResults) {
 	if certs.PantherSubdomain != nil {
+		domainName := "unknown"
+		if len(certs.PantherSubdomain.ValidationDetails.DomainNames) > 0 {
+			domainName = certs.PantherSubdomain.ValidationDetails.DomainNames[0]
+		}
 		log.Printf(
 			"For Panther Subdomain (%s), create a DNS record with the following information:\n",
-			certs.PantherSubdomain.ValidationDetails.DomainName,
+			domainName,
 		)
 		log.Printf("  Record Type:  %s\n", certs.PantherSubdomain.ValidationDetails.RecordType)
 		log.Printf("  Record Name:  %s\n", certs.PantherSubdomain.ValidationDetails.RecordName)
@@ -132,9 +143,13 @@ func printDNSValidationInstructions(certs state.CertificateResults) {
 	}
 
 	if certs.WildcardSubdomain != nil {
+		domainName := "unknown"
+		if len(certs.WildcardSubdomain.ValidationDetails.DomainNames) > 0 {
+			domainName = certs.WildcardSubdomain.ValidationDetails.DomainNames[0]
+		}
 		log.Printf(
 			"For Wildcard Certificate (%s), create a DNS record with the following information:\n",
-			certs.WildcardSubdomain.ValidationDetails.DomainName,
+			domainName,
 		)
 		log.Printf("  Record Type:  %s\n", certs.WildcardSubdomain.ValidationDetails.RecordType)
 		log.Printf("  Record Name:  %s\n", certs.WildcardSubdomain.ValidationDetails.RecordName)

--- a/pkg/cloudconnected/aws/certificates.go
+++ b/pkg/cloudconnected/aws/certificates.go
@@ -21,7 +21,7 @@ type CertificateRegistrationHelper struct {
 
 // CertificateValidationDetails contains the DNS record information needed for certificate validation
 type CertificateValidationDetails struct {
-	DomainName  string
+	DomainNames []string
 	RecordName  string
 	RecordValue string
 	RecordType  string
@@ -123,8 +123,14 @@ func (c *CertificateRegistrationHelper) getValidationDetails(
 			return CertificateValidationDetails{}, errors.New("no validation record found")
 		}
 
+		// Collect all domain names from the validation options
+		domainNames := make([]string, len(result.Certificate.DomainValidationOptions))
+		for i, opt := range result.Certificate.DomainValidationOptions {
+			domainNames[i] = aws.ToString(opt.DomainName)
+		}
+
 		return CertificateValidationDetails{
-			DomainName:  aws.ToString(validation.DomainName),
+			DomainNames: domainNames,
 			RecordName:  aws.ToString(validation.ResourceRecord.Name),
 			RecordValue: aws.ToString(validation.ResourceRecord.Value),
 			RecordType:  string(validation.ResourceRecord.Type),

--- a/pkg/cloudconnected/aws/certificates.go
+++ b/pkg/cloudconnected/aws/certificates.go
@@ -49,9 +49,6 @@ func NewCertificateRegistrationHelper(
 		return nil, errors.Wrap(err, "failed to create AWS config")
 	}
 
-	// Override region from our config
-	awsCfg.Region = cfg.AWSConfig.Region
-
 	// Create ACM client
 	client := acm.NewFromConfig(awsCfg)
 
@@ -66,7 +63,7 @@ func NewCertificateRegistrationHelper(
 func (c *CertificateRegistrationHelper) getACMClientForRegion(region string) (*acm.Client, error) {
 	awsCfg, err := util.GetAWSConfig(
 		c.ctx,
-		c.cfg.AWSConfig.Region,
+		region,
 		c.cfg.AWSConfig.AccessKeyID,
 		c.cfg.AWSConfig.SecretAccessKey,
 		c.cfg.AWSConfig.SessionToken,
@@ -74,9 +71,6 @@ func (c *CertificateRegistrationHelper) getACMClientForRegion(region string) (*a
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create AWS config")
 	}
-
-	// Override region
-	awsCfg.Region = region
 
 	return acm.NewFromConfig(awsCfg), nil
 }

--- a/pkg/cloudconnected/aws/certificates.go
+++ b/pkg/cloudconnected/aws/certificates.go
@@ -137,9 +137,13 @@ func (c *CertificateRegistrationHelper) getValidationDetails(
 }
 
 func (c *CertificateRegistrationHelper) RegisterPantherSubdomainCertificate() (CertificateRegistrationResult, error) {
+	pantherSubdomain := c.cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain
+	wildcardDomain := "*." + pantherSubdomain
+
 	input := &acm.RequestCertificateInput{
-		DomainName:       aws.String(c.cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain),
-		ValidationMethod: types.ValidationMethodDns,
+		DomainName:              aws.String(wildcardDomain),
+		ValidationMethod:        types.ValidationMethodDns,
+		SubjectAlternativeNames: []string{pantherSubdomain},
 	}
 
 	result, err := c.client.RequestCertificate(c.ctx, input)
@@ -147,7 +151,7 @@ func (c *CertificateRegistrationHelper) RegisterPantherSubdomainCertificate() (C
 		return CertificateRegistrationResult{}, errors.Wrapf(
 			err,
 			"failed to request certificate for panther subdomain (%s)",
-			c.cfg.AWSConfig.DomainCertificateConfiguration.PantherSubdomain,
+			pantherSubdomain,
 		)
 	}
 

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -120,7 +120,7 @@ func (m *Manager) UpdateCertificateState(
 	certRecord := &CertificateRecord{
 		CertificateArn: result.CertificateArn,
 		ValidationDetails: CertificateValidationRecord{
-			DomainName:  result.ValidationDetails.DomainName,
+			DomainNames: result.ValidationDetails.DomainNames,
 			RecordName:  result.ValidationDetails.RecordName,
 			RecordValue: result.ValidationDetails.RecordValue,
 			RecordType:  result.ValidationDetails.RecordType,

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -256,7 +256,7 @@ func TestStateUpdates(t *testing.T) {
 		certResult := aws.CertificateRegistrationResult{
 			CertificateArn: "arn:aws:acm:us-west-2:123456789012:certificate/1234-5678-9012",
 			ValidationDetails: aws.CertificateValidationDetails{
-				DomainName:  "test.example.com",
+				DomainNames: []string{"test.example.com"},
 				RecordName:  "_1234.test.example.com",
 				RecordValue: "verification-value-1234",
 				RecordType:  "CNAME",
@@ -273,8 +273,8 @@ func TestStateUpdates(t *testing.T) {
 		assert.Equal(t, certResult.CertificateArn, state.AWSCertificatesResults.PantherSubdomain.CertificateArn)
 		assert.Equal(
 			t,
-			certResult.ValidationDetails.DomainName,
-			state.AWSCertificatesResults.PantherSubdomain.ValidationDetails.DomainName,
+			certResult.ValidationDetails.DomainNames,
+			state.AWSCertificatesResults.PantherSubdomain.ValidationDetails.DomainNames,
 		)
 		assert.Equal(
 			t,
@@ -297,7 +297,7 @@ func TestStateUpdates(t *testing.T) {
 		wildcardResult := aws.CertificateRegistrationResult{
 			CertificateArn: "arn:aws:acm:us-west-2:123456789012:certificate/9876-5432-1098",
 			ValidationDetails: aws.CertificateValidationDetails{
-				DomainName:  "*.example.com",
+				DomainNames: []string{"*.example.com"},
 				RecordName:  "_9876.example.com",
 				RecordValue: "verification-value-9876",
 				RecordType:  "CNAME",
@@ -313,8 +313,8 @@ func TestStateUpdates(t *testing.T) {
 		assert.Equal(t, wildcardResult.CertificateArn, state.AWSCertificatesResults.WildcardSubdomain.CertificateArn)
 		assert.Equal(
 			t,
-			wildcardResult.ValidationDetails.DomainName,
-			state.AWSCertificatesResults.WildcardSubdomain.ValidationDetails.DomainName,
+			wildcardResult.ValidationDetails.DomainNames,
+			state.AWSCertificatesResults.WildcardSubdomain.ValidationDetails.DomainNames,
 		)
 		assert.True(t, state.AWSCertificatesResults.WildcardSubdomain.IsIssued)
 

--- a/pkg/state/row.go
+++ b/pkg/state/row.go
@@ -16,10 +16,10 @@ import (
 
 // CertificateValidationRecord represents the DNS validation details for a certificate
 type CertificateValidationRecord struct {
-	DomainName  string `json:"domain_name"`
-	RecordName  string `json:"record_name"`
-	RecordValue string `json:"record_value"`
-	RecordType  string `json:"record_type"`
+	DomainNames []string `json:"domain_names"`
+	RecordName  string   `json:"record_name"`
+	RecordValue string   `json:"record_value"`
+	RecordType  string   `json:"record_type"`
 }
 
 // CertificateRecord represents a registered certificate and its validation details

--- a/pkg/state/row_test.go
+++ b/pkg/state/row_test.go
@@ -83,7 +83,7 @@ func TestCertificateResults(t *testing.T) {
 		PantherSubdomain: &CertificateRecord{
 			CertificateArn: "arn:aws:acm:region:account:certificate/id",
 			ValidationDetails: CertificateValidationRecord{
-				DomainName:  "test.example.com",
+				DomainNames: []string{"test.example.com"},
 				RecordName:  "_validation.test.example.com",
 				RecordValue: "validation-value",
 				RecordType:  "CNAME",
@@ -111,8 +111,8 @@ func TestCertificateResults(t *testing.T) {
 		assert.Equal(t, results.PantherSubdomain.CertificateArn, deserializedResults.PantherSubdomain.CertificateArn)
 		assert.Equal(
 			t,
-			results.PantherSubdomain.ValidationDetails.DomainName,
-			deserializedResults.PantherSubdomain.ValidationDetails.DomainName,
+			results.PantherSubdomain.ValidationDetails.DomainNames,
+			deserializedResults.PantherSubdomain.ValidationDetails.DomainNames,
 		)
 		assert.Equal(
 			t,


### PR DESCRIPTION
## Overview

<!-- What did you add? -->
- added registering the wildcard in the target region, not just us-east-1

<!-- What did you change? -->
- changed registration in us-east-1 to only create one certificate request for the subdomain + wildcard

<!-- What did you remove? -->
- removed...

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [x] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [x] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- slack: https://panther-labs.slack.com/archives/C02MX5XG8UT/p1750959482114549