### PR TITLE
(chore): Don't poll for certificates if domain validation is manual

### DIFF
--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -110,6 +110,24 @@ func pollCertificateUntilIssued(
 }
 
 func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManager *state.Manager, forceCheck bool) error {
+	// Skip polling if AutoRegisterValidationDomains is false (unless force check is explicitly requested)
+	if !cfg.AWSConfig.DomainCertificateConfiguration.AutoRegisterValidationDomains && !forceCheck {
+		log.Println("Skipping certificate status polling - AutoRegisterValidationDomains is false")
+		state := stateManager.GetState()
+		certs := state.AWSCertificatesResults
+
+		// Still print DNS validation instructions if certificates are not issued
+		if (certs.PantherSubdomain != nil && !certs.PantherSubdomain.IsIssued) ||
+			(certs.WildcardSubdomain != nil && !certs.WildcardSubdomain.IsIssued) {
+			util.LogRedln(
+				"Some certificates are still pending validation. Please ensure you have created the following DNS records:",
+			)
+			printDNSValidationInstructions(certs)
+		}
+
+		return nil
+	}
+
 	certHelper, err := aws.NewCertificateRegistrationHelper(ctx, cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize certificate registration helper")


### PR DESCRIPTION
<!--
This repo is made possible by contributors like you. Thank you.
Please include a high level overview of the changes made
-->

## Overview

<!-- What did you add? -->
- added...

<!-- What did you change? -->
- No longer polling for certificates if `AutoRegisterValidationDomains` is false in config

<!-- What did you remove? -->
- removed...

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [ ] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: