### PR TITLE
EPD-4839 prevent output if certs not issued

### DIFF
--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -125,10 +125,11 @@ func pollCertificateUntilIssued(
 	return true, nil
 }
 
-func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManager *state.Manager, forceCheck bool) error {
+// returns true if certificates are issued
+func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManager *state.Manager, forceCheck bool) (bool, error) {
 	certHelper, err := aws.NewCertificateRegistrationHelper(ctx, cfg)
 	if err != nil {
-		return errors.Wrap(err, "failed to initialize certificate registration helper")
+		return false, errors.Wrap(err, "failed to initialize certificate registration helper")
 	}
 
 	state := stateManager.GetState()
@@ -143,7 +144,7 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 			ctx, certHelper, certs.PantherSubdomain.CertificateArn, false, "panther", certs.PantherSubdomain.AutoRegistrationSucceeded,
 		)
 		if err != nil {
-			return errors.Wrap(err, "failed to check panther subdomain certificate status")
+			return false, errors.Wrap(err, "failed to check panther subdomain certificate status")
 		}
 
 		if issued {
@@ -164,7 +165,7 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 				},
 				true,
 			); err != nil {
-				return errors.Wrap(err, "failed to update panther certificate state")
+				return false, errors.Wrap(err, "failed to update panther certificate state")
 			}
 			log.Println("Panther subdomain certificate has been issued")
 		} else {
@@ -187,7 +188,7 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 			ctx, certHelper, certs.WildcardSubdomain.CertificateArn, true, "wildcard", certs.WildcardSubdomain.AutoRegistrationSucceeded,
 		)
 		if err != nil {
-			return errors.Wrap(err, "failed to check wildcard certificate status")
+			return false, errors.Wrap(err, "failed to check wildcard certificate status")
 		}
 
 		if issued {
@@ -208,7 +209,7 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 				},
 				true,
 			); err != nil {
-				return errors.Wrap(err, "failed to update wildcard certificate state")
+				return false, errors.Wrap(err, "failed to update wildcard certificate state")
 			}
 			log.Println("Wildcard certificate has been issued")
 		} else {
@@ -232,9 +233,10 @@ func checkCertificateStatus(ctx context.Context, cfg *config.Config, stateManage
 			"Some certificates are still pending validation. Please ensure you have created the following DNS records:",
 		)
 		printDNSValidationInstructions(certs)
+		return false, nil
 	}
 
-	return nil
+	return true, nil
 }
 
 func printDNSValidationInstructions(certs state.CertificateResults) {

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -74,8 +74,18 @@ func main() {
 	}
 
 	// Check certificate issuance status
-	if err := checkCertificateStatus(ctx, cfg, stateManager, a.ForceCheckCertificates); err != nil {
+	isIssued, err := checkCertificateStatus(ctx, cfg, stateManager, a.ForceCheckCertificates)
+	if err != nil {
 		log.Fatalf("failed to check certificate status: %v\n", err)
+	}
+	if !isIssued {
+		// dont print output of the run if the certs are not issued yet
+		// customer needs to manually create the DNS records per instructions
+		// emitted in checkCertificateStatus. once created the customer can run the
+		// command again which will verify the certs are issued,
+		// and then the output file will be emitted
+		util.LogRedln("Run this program again once the above DNS records have been created")
+		return
 	}
 
 	// show this run's results


### PR DESCRIPTION
## Overview

<!-- What did you add? -->
- added...

<!-- What did you change? -->
- changed: the output json will not be printed, nor written to file if the certs are not issued: otherwise we hide the instructions behind a ton of output, and users may think their state is valid despite the certs not being issued yet.

<!-- What did you remove? -->
- removed...

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [ ] This change has been tested against a real environment

Tested manually: original behavior outputs instructions followed by the normal output. its a lot of output (cant show all in screenshot. theres even json below this), and gives impression that the operation succeeded.


<img width="716" height="719" alt="Screenshot 2026-02-03 at 4 17 25 PM" src="https://github.com/user-attachments/assets/6217262d-6a66-4519-8f6a-1e3d8307dc1a" />

after change: certs not issued yet, its the last output you see and it prompts to run again after creating the DNS records:

<img width="767" height="315" alt="Screenshot 2026-02-03 at 4 07 52 PM" src="https://github.com/user-attachments/assets/90565b2b-e157-418d-bdcf-085eec4f4854" />

running it again after creating the DNS records runs the validation again, this time it sees that its issued, and it prints the output

## Breadcrumbs (for Panther Labs Engineers)

- jira: https://panther-labs.atlassian.net/browse/EPD-4839