### PR TITLE
Adding --only-readiness-check flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ here: [example-config-existing-snowflake-acct.yml](example-config-existing-snowf
 ```
 
 
+#### Run Only the AWS Readiness Check
+
+Use `--only-readiness-check` to invoke the `PantherReadinessCheck` Lambda and exit immediately,
+skipping datalake setup and all certificate steps. This is useful for validating AWS IAM
+permissions and diagnosing issues caused by Service Control Policies (SCPs) or Control Tower
+policies without running the full provisioning flow. The check is always re-run, even if a
+previous run already recorded a passing result.
+
+```bash
+./panther-cloud-connected-setup --config-file config.yml --only-readiness-check
+```
+
 #### Cleaning Local State
 
 ```bash

--- a/cmd/panther-cloud-connected-setup/args.go
+++ b/cmd/panther-cloud-connected-setup/args.go
@@ -17,6 +17,7 @@ type args struct {
 	SkipAWSReadinessCheck   bool   `arg:"--skip-aws-readiness-check" help:"Skip the AWS readiness check"`
 	SkipDatalakeSetup       bool   `arg:"--skip-datalake-setup"      help:"Skip the datalake setup entirely"`
 	ForceCheckCertificates  bool   `arg:"--force-check-certificates" help:"Force checking certificate issuance status even if already marked as issued"`
+	OnlyReadinessCheck      bool   `arg:"--only-readiness-check"     help:"Run only the AWS readiness check and exit, skipping datalake setup and certificate steps"`
 }
 
 // validateArgs checks that the arguments passed to the program

--- a/cmd/panther-cloud-connected-setup/aws.go
+++ b/cmd/panther-cloud-connected-setup/aws.go
@@ -342,10 +342,10 @@ func setupAWS(ctx context.Context, cfg *config.Config, stateManager *state.Manag
 	return nil
 }
 
-func runReadinessCheck(ctx context.Context, cfg *config.Config, stateManager *state.Manager) error {
+func runReadinessCheck(ctx context.Context, cfg *config.Config, stateManager *state.Manager, force bool) error {
 	currentState := stateManager.GetState()
 
-	if !currentState.AWSReadinessCheckSucceeded {
+	if !currentState.AWSReadinessCheckSucceeded || force {
 		readinessCheck, err := panther.NewReadinessCheck(ctx, cfg.AWSConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to initialize readiness check")

--- a/cmd/panther-cloud-connected-setup/main.go
+++ b/cmd/panther-cloud-connected-setup/main.go
@@ -51,22 +51,28 @@ func main() {
 	}
 
 	// Setup the Datalake if not already done. Error handling is done in the function.
-	if !a.SkipDatalakeSetup {
+	if !a.SkipDatalakeSetup && !a.OnlyReadinessCheck {
 		if err := setupDatalake(ctx, cfg, stateManager); err != nil {
 			log.Fatalf("failed to setup datalake: %v\n", err)
 		}
+	} else if a.OnlyReadinessCheck {
+		log.Println("Skipping datalake setup - --only-readiness-check specified")
 	} else {
 		log.Println("Skipping datalake setup - --skip-datalake-setup specified")
 	}
 
 	// We allow users to skip the readiness check, whether it ran successfully or not.
 	if !a.SkipAWSReadinessCheck {
-		// Run readiness check if not already done
-		if err := runReadinessCheck(ctx, cfg, stateManager); err != nil {
+		// Run readiness check if not already done (or always if --only-readiness-check)
+		if err := runReadinessCheck(ctx, cfg, stateManager, a.OnlyReadinessCheck); err != nil {
 			log.Fatalf("failed to run readiness check: %v\n", err)
 		}
 	} else {
 		log.Println("Skipping readiness check - --skip-aws-readiness-check specified")
+	}
+
+	if a.OnlyReadinessCheck {
+		return
 	}
 
 	if err := setupCertificates(ctx, cfg, stateManager); err != nil {

--- a/example-config-only-readiness-check.yml
+++ b/example-config-only-readiness-check.yml
@@ -1,0 +1,23 @@
+AWSConfig:
+  AccessKeyID: <YOUR AWS ACCESS KEY ID> # This is optional if you are using the default AWS profile.
+  SecretAccessKey: <YOUR AWS SECRET ACCESS KEY> # This is optional if you are using the default AWS profile.
+  SessionToken: <YOUR AWS SESSION TOKEN> # This is optional if you are using the default AWS profile.
+  CloudFormationConfig:
+    DeploymentRoleName: PantherDeploymentRole # WE RECOMMEND USING THIS VALUE
+    IdentityAccountId: <ASK FOR THIS INFORMATION FROM PANTHER>
+    OpsAccountId: <ASK FOR THIS INFORMATION FROM PANTHER>
+  DomainCertificateConfiguration:
+    PantherSubdomain: panther.yourdomain.com # not used by --only-readiness-check, but required by schema validation
+
+PantherAccountConfig:
+  DesiredAccountName: <YOUR PREFERRED PANTHER ACCOUNT NAME> # shown in Panther UI - "My Cool Panther Account"
+  AdminUserFirstName: <YOUR ADMIN USER'S FIRST NAME>
+  AdminUserLastName: <YOUR ADMIN USER'S LAST NAME>
+  AdminEmail: <YOUR ADMIN USER'S EMAIL>
+  Edition: ENTERPRISE
+  Region: <YOUR PANTHER REGION> # Format this as an AWS region name - e.g. us-west-2
+  IpAddressAllowList: [] # A list of IP addresses formatted as CIDR blocks that are allowed to access the Panther UI.
+
+# DatabricksConfig is used as a placeholder to satisfy schema validation.
+# Datalake setup is skipped entirely when --only-readiness-check is passed.
+DatabricksConfig: {}

--- a/example-config-only-readiness-check.yml
+++ b/example-config-only-readiness-check.yml
@@ -16,7 +16,6 @@ PantherAccountConfig:
   AdminEmail: <YOUR ADMIN USER'S EMAIL>
   Edition: ENTERPRISE
   Region: <YOUR PANTHER REGION> # Format this as an AWS region name - e.g. us-west-2
-  IpAddressAllowList: [] # A list of IP addresses formatted as CIDR blocks that are allowed to access the Panther UI.
 
 # DatabricksConfig is used as a placeholder to satisfy schema validation.
 # Datalake setup is skipped entirely when --only-readiness-check is passed.


### PR DESCRIPTION
<!--
This repo is made possible by contributors like you. Thank you.
Please include a high level overview of the changes made
-->

## Overview

<!-- What did you add? -->
- The ability to run the readiness check only with a flag
<img width="871" height="488" alt="image" src="https://github.com/user-attachments/assets/160f7e64-28da-457a-81eb-cd44a4b39c48" />

<!-- What did you change? -->
- changed...

<!-- What did you remove? -->
- removed...

<!-- Make sure you have some detail and description laid out above about the what and why of this change -->
## Testing:

- [ ] This change added new test coverage
- [ ] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [ ] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: