### PR TITLE
ci: harden GitHub Actions workflows based on zizmor audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
       - "@panther-labs/admin"
     assignees:
       - "@panther-labs/admin"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
         with:
@@ -30,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
@@ -61,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout # zizmor: ignore[artipacked] workflow needs credentials to push tags
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
         with:
           go-version: '>=1.24'
-          cache: true
+          cache: true # zizmor: ignore[cache-poisoning] all triggers require write access
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,18 @@ on:
   workflow_dispatch:
 
 
-permissions:
-  contents: write
-  packages: write
-  issues: write
+permissions: {}
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+    outputs:
+      release_tag: ${{ steps.release_tag.outputs.tag }} # expose value to other jobs
     steps:
       - name: Checkout # zizmor: ignore[artipacked] workflow needs credentials to push tags
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -87,3 +90,74 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set release tag for homebrew
+        id: release_tag
+        env:
+          CREATE_TAG: ${{ steps.create_tag.outputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Use create_tag output when we created the tag (push to main),
+          # otherwise use the ref we're running on (tag push). Exposed as job output release_tag.
+          if [ -n "${CREATE_TAG}" ]; then
+            echo "tag=${CREATE_TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${REF_NAME}" >> $GITHUB_OUTPUT
+          fi
+
+  homebrew-taps-pr:  # Opens a PR in homebrew-taps to update the panther-cli formula after a release
+    name: Homebrew Taps PR
+    runs-on: macos-latest # So util/update-formula.sh (sed -i '') works without changing the script
+    needs: release
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
+    steps:
+      # Clone homebrew-taps so we can run its update script and push a branch using the bot token
+      - name: Checkout homebrew-taps # zizmor: ignore[artipacked] needs credentials for git push
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: panther-labs/homebrew-taps
+          ref: main
+          token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
+          path: homebrew-taps
+
+      # Homebrew script expects version without leading "v" (e.g. 0.0.29). ${RELEASE_TAG#v} strips the "v"
+      - name: Update formula
+        working-directory: homebrew-taps
+        run: ./util/update-formula.sh "${RELEASE_TAG#v}"
+
+      # Import GPG key so commits are verified
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec #v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          workdir: homebrew-taps
+
+      # Commit, push, and create PR only if the script changed files
+      - name: Commit, push, and create PR
+        working-directory: homebrew-taps
+        env:
+          GH_TOKEN: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
+        run: |
+          git config --global user.email "github-service-account-automation@panther.io"
+          git config --global user.name "panther-bot-automation"
+          git checkout -b "update-panther-cli-${RELEASE_TAG}"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No formula changes for ${RELEASE_TAG}, skipping PR creation"
+            exit 0
+          fi
+          git commit -m "Update panther-cli to ${RELEASE_TAG}"
+          git push --force-with-lease origin "update-panther-cli-${RELEASE_TAG}"
+          gh pr create \
+            --repo panther-labs/homebrew-taps \
+            --base main \
+            --head "update-panther-cli-${RELEASE_TAG}" \
+            --title "Update panther-cli to ${RELEASE_TAG}" \
+            --body "Automated update from panther-cli release workflow" \
+            || echo "PR already exists for ${RELEASE_TAG}, skipping"

--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ The following subsection provides specific notes about the expectations the tool
 
 For Panther devs:
 
-If making changes to this repository, make sure to also update the [homebrew taps repository](https://github.com/panther-labs/homebrew-taps) after merge so people downloading this via homebrew can get the latest version
+After merging your changes to main in this repository, the release workflow automatically opens a PR in the [homebrew taps repository](https://github.com/panther-labs/homebrew-taps). Approve and merge that PR so people installing via Homebrew get the latest version.


### PR DESCRIPTION
## Overview

Ran [zizmor](https://docs.zizmor.sh/) on the repo and addressed findings. There were three issues that were flagged I accepted as ignorable (possible cache poisoning on setup-go, persist credentials on the release workflow, secrets accessed outside of env).

- added
  - dependabot cooldown, I'll admit this was my motivation to tackle this 
- changed
  - Scoped down workflow permissions and moved them to job level where applicable
  - Used persist-credentials: false where possibl 

## Testing:

- [ ] This change added new test coverage
- [x] This change is configuration-only (e.g. `.github/`, `.goreleaser.yaml`, etc)
- [ ] This change has been tested against a real environment

## Breadcrumbs (for Panther Labs Engineers)

- jira: