### PR TITLE
Format with gofumpt to fix CI format check

### DIFF
--- a/pkg/cloudconnected/config/config.go
+++ b/pkg/cloudconnected/config/config.go
@@ -176,7 +176,8 @@ func (cfg *Config) setupSnowflakeConfig() (err error) {
 			privateKey, err := os.ReadFile(cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath)
 			if err != nil {
 				// Wrap error for better context
-				return errors.Wrapf(err,
+				return errors.Wrapf(
+					err,
 					"failed to read OrgAdminPrivateKey from path '%s'",
 					cfg.SnowflakeConfig.NewAccountConfig.OrgConfig.OrgAdminPrivateKeyPath,
 				)

--- a/pkg/cloudconnected/config/validate.go
+++ b/pkg/cloudconnected/config/validate.go
@@ -15,10 +15,12 @@ func init() {
 		validate.RegisterValidation("validAcctName", validateSnowflakeAccountName),
 		"couldn't register validAcctName validation",
 	)
-	util.Must(validate.RegisterValidation("validAdminName", validateAdminName),
+	util.Must(
+		validate.RegisterValidation("validAdminName", validateAdminName),
 		"couldn't register validAdminName validation",
 	)
-	util.Must(validate.RegisterValidation("validPantherRegion", validatePantherRegion),
+	util.Must(
+		validate.RegisterValidation("validPantherRegion", validatePantherRegion),
 		"couldn't register validPantherRegion validation",
 	)
 	validate.RegisterStructValidation(validateEditionsMatch, Config{})

--- a/pkg/rsapem/rsa_test.go
+++ b/pkg/rsapem/rsa_test.go
@@ -36,7 +36,7 @@ func Test_RSAPEMKeys(t *testing.T) {
 		assert.Equal(t, "RSA PUBLIC KEY", block.Type)
 		decodedKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 		require.NoError(t, err)
-		decodedRSA, ok := (decodedKey).(*rsa.PublicKey)
+		decodedRSA, ok := decodedKey.(*rsa.PublicKey)
 		require.True(t, ok)
 		assert.Equal(t, pubkey, *decodedRSA)
 	})

--- a/pkg/state/row_test.go
+++ b/pkg/state/row_test.go
@@ -57,13 +57,15 @@ func TestReadinessCheckResults(t *testing.T) {
 		assert.Len(t, deserializedResults.DeploymentRoleReadinessResults, 2)
 
 		// Check first result
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			results.DeploymentRoleReadinessResults[0]["message"],
 			deserializedResults.DeploymentRoleReadinessResults[0]["message"],
 		)
 
 		// Check second result
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			results.DeploymentRoleReadinessResults[1]["severity"],
 			deserializedResults.DeploymentRoleReadinessResults[1]["severity"],
 		)

--- a/pkg/util/snowflake.go
+++ b/pkg/util/snowflake.go
@@ -133,7 +133,8 @@ func (c *SnowflakeConnectionConfig) GetDSN() (string, error) {
 
 	dsn, err := gosnowflake.DSN(connConfig)
 	if err != nil {
-		return "", errors.Wrapf(err,
+		return "", errors.Wrapf(
+			err,
 			"failed to generate Snowflake DSN for credentials: gosnowflake.Config: %s",
 			pp.Sprint(c),
 		)


### PR DESCRIPTION
The `format` CI job installs standalone `gofumpt@latest` (now **v0.10.0**) and runs `gofumpt -l .`. The repo was last formatted with an older gofumpt, so v0.10.0 flags 5 files. This fails the `format` check on **every** open PR (e.g. #151, #150), independent of their changes.

This applies `gofumpt -w .` to bring those files into line. Changes are whitespace-only (multi-line call arg layout + one redundant type-assertion paren). After this: `gofumpt -l .` is clean, `golangci-lint run` reports 0 issues, and the build passes.

Files:
- `pkg/cloudconnected/config/config.go`
- `pkg/cloudconnected/config/validate.go`
- `pkg/rsapem/rsa_test.go`
- `pkg/state/row_test.go`
- `pkg/util/snowflake.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)